### PR TITLE
Fix document sample code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ https://devdocs.line.me/en/#error-response
 
     try:
         line_bot_api.push_message('to', TextSendMessage(text='Hello World!'))
-    except linebot.LineBotApiError as e:
+    except linebot.exceptions.LineBotApiError as e:
         print(e.status_code)
         print(e.error.message)
         print(e.error.details)

--- a/tests/api/test_send_image_message.py
+++ b/tests/api/test_send_image_message.py
@@ -88,5 +88,6 @@ class TestLineBotApi(unittest.TestCase):
             }
         )
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We cannot import `LineBotApiError` from `linebot`. It should be from `linebot.exceptions`