### PR TITLE
Add python 3.6 test for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install: pip install tox-travis
 


### PR DESCRIPTION
Python 3.6.0 was released on 2016/12/23 and Travis CI supports this version now.

https://docs.travis-ci.com/user/languages/python/#Choosing-Python-versions-to-test-against 