### PR TITLE
Specify pydoctyle version due to dependency issue (workaround)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ basepython = python3.5
 deps =
     flake8
     flake8-docstrings
+    pydocstyle==1.1.1
 commands = flake8 linebot/
 
 [testenv:py35-flake8-other]


### PR DESCRIPTION
Current flake8-docstring (on 2017/4/26) try to use latest version of pydocstyle - 2.0.0, but it is not stable for now.
I got following error due to using flake8-docstrings w/ pydocstyle v2.0.0.

```
Traceback (most recent call last):
  File "/Users/JP11542/.pyenv/versions/3.5.2/lib/python3.5/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/Users/JP11542/.ghq/github.com/okdtsk/line-bot-sdk-python/.tox/py35-flake8-src/lib/python3.5/site-packages/flake8/checker.py", line 642, in _run_checks
    return checker.run_checks()
  File "/Users/JP11542/.ghq/github.com/okdtsk/line-bot-sdk-python/.tox/py35-flake8-src/lib/python3.5/site-packages/flake8/checker.py", line 573, in run_checks
    self.run_ast_checks()
  File "/Users/JP11542/.ghq/github.com/okdtsk/line-bot-sdk-python/.tox/py35-flake8-src/lib/python3.5/site-packages/flake8/checker.py", line 480, in run_ast_checks
    checker = self.run_check(plugin, tree=ast)
  File "/Users/JP11542/.ghq/github.com/okdtsk/line-bot-sdk-python/.tox/py35-flake8-src/lib/python3.5/site-packages/flake8/checker.py", line 429, in run_check
    return plugin['plugin'](**arguments)
  File "/Users/JP11542/.ghq/github.com/okdtsk/line-bot-sdk-python/.tox/py35-flake8-src/lib/python3.5/site-packages/flake8_docstrings.py", line 53, in __init__
    self.checker = pep257.PEP257Checker()
AttributeError: module 'pydocstyle' has no attribute 'PEP257Checker'
```