### PR TITLE
Fix serialization error of Beacon model.

### DIFF
--- a/examples/flask-kitchensink/app.py
+++ b/examples/flask-kitchensink/app.py
@@ -250,8 +250,9 @@ def handle_postback(event):
 def handle_beacon(event):
     line_bot_api.reply_message(
         event.reply_token,
-        TextSendMessage(text='Got beacon event. hwid={}, device_message={}'
-                             .format(event.beacon.hwid, event.beacon.device_message)))
+        TextSendMessage(
+            text='Got beacon event. hwid={}, device_message(hex string)={}'.format(event.beacon.hwid,
+                                                                                     event.beacon.dm)))
 
 
 if __name__ == "__main__":

--- a/examples/flask-kitchensink/app.py
+++ b/examples/flask-kitchensink/app.py
@@ -251,8 +251,8 @@ def handle_beacon(event):
     line_bot_api.reply_message(
         event.reply_token,
         TextSendMessage(
-            text='Got beacon event. hwid={}, device_message(hex string)={}'.format(event.beacon.hwid,
-                                                                                     event.beacon.dm)))
+            text='Got beacon event. hwid={}, device_message(hex string)={}'.format(
+                event.beacon.hwid, event.beacon.dm)))
 
 
 if __name__ == "__main__":

--- a/linebot/models/events.py
+++ b/linebot/models/events.py
@@ -287,11 +287,20 @@ class Beacon(Base):
 
         :param str type: Type of beacon event
         :param str hwid: Hardware ID of the beacon that was detected
-        :param str dm: Optional. Device message of beacon that was detected in bytearray
+        :param str dm: Optional. Device message of beacon which is hex string
         :param kwargs:
         """
         super(Beacon, self).__init__(**kwargs)
 
         self.type = type
         self.hwid = hwid
-        self.device_message = bytearray.fromhex(dm) if dm is not None else None
+        self.dm = dm
+
+    @property
+    def device_message(self):
+        """Get dm(device_message) as bytearray.
+
+        :rtype: bytearray
+        :return:
+        """
+        return bytearray.fromhex(self.dm) if self.dm is not None else None

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -204,6 +204,7 @@ class TestWebhookParser(unittest.TestCase):
         self.assertEqual(events[11].source.sender_id, 'U206d25c2ea6bd87c17655609a1c37cb8')
         self.assertEqual(events[11].beacon.hwid, 'd41d8cd98f')
         self.assertEqual(events[11].beacon.type, 'enter')
+        self.assertEqual(events[11].beacon.dm, None)
         self.assertEqual(events[11].beacon.device_message, None)
 
         # BeaconEvent, SourceUser (with device message)
@@ -217,6 +218,7 @@ class TestWebhookParser(unittest.TestCase):
         self.assertEqual(events[12].source.sender_id, 'U206d25c2ea6bd87c17655609a1c37cb8')
         self.assertEqual(events[12].beacon.hwid, 'd41d8cd98f')
         self.assertEqual(events[12].beacon.type, 'enter')
+        self.assertEqual(events[12].beacon.dm, '1234567890abcdef')
         self.assertEqual(events[12].beacon.device_message, bytearray(b'\x124Vx\x90\xab\xcd\xef'))
 
 


### PR DESCRIPTION
`__str__` and `__repr__` of `Base` class uses json serialization.
But `bytearray` cannot be json serialized.