### PR TITLE
Support Python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -623,6 +623,7 @@ Test by using tox. We test against the following versions.
 -  3.3
 -  3.4
 -  3.5
+-  3.6
 
 To run all tests and to run ``flake8`` against all versions, use:
 

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Topic :: Software Development"
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py35-flake8-src, py35-flake8-tests
+envlist = py27, py33, py34, py35, py36, py36-flake8-src, py36-flake8-tests, py36-flake8-other
 
 [testenv]
 deps =
@@ -7,21 +7,21 @@ deps =
     -r{toxinidir}/requirements-test.txt
 commands = py.test -v tests/
 
-[testenv:py35]
-basepython = python3.5
+[testenv:py36]
+basepython = python3.6
 deps = {[testenv]deps}
 commands = py.test -v --cov=linebot tests/
 
-[testenv:py35-flake8-src]
-basepython = python3.5
+[testenv:py36-flake8-src]
+basepython = python3.6
 deps =
     flake8
     flake8-docstrings
     pydocstyle==1.1.1
 commands = flake8 linebot/
 
-[testenv:py35-flake8-other]
-basepython = python3.5
+[testenv:py36-flake8-other]
+basepython = python3.6
 deps =
     flake8
 commands = flake8 tests/ examples/


### PR DESCRIPTION
Currently Python latest version is 3.6.1, so we should support this version.
Fortunately there is no problem to run all tests on python 3.6 :sunglasses:

* On TravisCI, this repo already support 3.6. #33