### PR TITLE
Change docstrings to use imperative mood to go test well with pydocstyle v2.0

### DIFF
--- a/linebot/models/base.py
+++ b/linebot/models/base.py
@@ -111,7 +111,7 @@ class Base(object):
 
     @staticmethod
     def get_or_new_from_json_dict(data, cls):
-        """Helper function.
+        """Get `cls` object w/ deserialization from json if needed.
 
         If data is instance of cls, return data.
         Else if data is instance of dict, create instance from dict.
@@ -133,7 +133,7 @@ class Base(object):
     def get_or_new_from_json_dict_with_types(
             data, cls_map, type_key='type'
     ):
-        """Helper function.
+        """Get `cls` object w/ deserialization from json by using type key hint if needed.
 
         If data is instance of one of cls, return data.
         Else if data is instance of dict, create instance from dict.

--- a/linebot/models/sources.py
+++ b/linebot/models/sources.py
@@ -36,7 +36,7 @@ class Source(with_metaclass(ABCMeta, Base)):
 
     @abstractproperty
     def sender_id(self):
-        """Helper method.
+        """Abstract property of id to send a message.
 
         If SourceUser, return user_id.
         If SourceGroup, return group_id.
@@ -69,9 +69,7 @@ class SourceUser(Source):
 
     @property
     def sender_id(self):
-        """Helper method.
-
-        Alias of user_id.
+        """Alias of user_id.
 
         :rtype: str
         :return:
@@ -100,9 +98,7 @@ class SourceGroup(Source):
 
     @property
     def sender_id(self):
-        """Helper method.
-
-        Alias of group_id.
+        """Alias of group_id.
 
         :rtype: str
         :return:
@@ -131,13 +127,7 @@ class SourceRoom(Source):
 
     @property
     def sender_id(self):
-        """Helper method.
-
-        Alias of room_id.
-
-        If SourceUser, return user_id.
-        If SourceGroup, return group_id.
-        If SourceRoom, return room_id.
+        """Alias of room_id.
 
         :rtype: str
         :return:

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ basepython = python3.5
 deps =
     flake8
     flake8-docstrings
-    pydocstyle==1.1.1
 commands = flake8 linebot/
 
 [testenv:py35-flake8-other]


### PR DESCRIPTION
From pydocstyle v2.0, D401 error raises when flake8 finds non-imperative mood phrase in first line of docstring.
Some methods/properties have blacklisted phrase, **'Helper'**, which leads flake8-docstrings test to fail.

ref) https://github.com/PyCQA/pydocstyle/commit/da8a3ceec10df0ce38190c19bb65fdc63f437f4e#diff-defe23c4dae3ec774b30a5390a18daf0R60