### PR TITLE
Change 'postback.params' type from python object to dict.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -577,10 +577,7 @@ Event
     - reply\_token
     - postback: Postback
         - data
-        - params: Params
-          - date
-          - time
-          - datetime
+        - params: dict
 - BeaconEvent
     - type
     - timestamp

--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -31,7 +31,6 @@ from .events import (  # noqa
     PostbackEvent,
     BeaconEvent,
     Postback,
-    Params,
     Beacon,
 )
 from .imagemap import (  # noqa

--- a/linebot/models/events.py
+++ b/linebot/models/events.py
@@ -269,50 +269,15 @@ class Postback(Base):
         """__init__ method.
 
         :param str data: Postback data
-        :param params: JSON object with the date and time
+        :param dict params: JSON object with the date and time
             selected by a user through a datetime picker action.
             Only returned for postback actions via the datetime picker.
-        :type params: T <= :py:class:`linebot.models.events.Params`
         :param kwargs:
         """
         super(Postback, self).__init__(**kwargs)
 
         self.data = data
-        self.params = self.get_or_new_from_json_dict(
-            params, Params
-        )
-
-
-class Params(Base):
-    """Params.
-
-    Object with the date and time selected by a user
-    through a datetime picker action.
-    The format for the full-date, time-hour, and time-minute
-    as shown below follow the RFC3339 protocol.
-
-    https://devdocs.line.me/en/#postback-params-object
-    """
-
-    def __init__(self, date=None, time=None, datetime=None, **kwargs):
-        """__init__ method.
-
-        :param str date: Date selected by user.
-            Only included in the date mode.
-            Format: full-date
-        :param str time: Time selected by the user.
-            Only included in the time mode.
-            Format: time-hour":"time-minute
-        :param str datetime: Date and time selected by the user.
-            Only included in the datetime mode.
-            Format: full-date"T"time-hour":"time-minute
-        :param kwargs:
-        """
-        super(Params, self).__init__(**kwargs)
-
-        self.date = date
-        self.time = time
-        self.datetime = datetime
+        self.params = params
 
 
 class Beacon(Base):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -16,8 +16,8 @@ from __future__ import unicode_literals, absolute_import
 
 import os
 import unittest
-
 from builtins import open
+
 from linebot import (
     SignatureValidator, WebhookParser, WebhookHandler
 )
@@ -26,8 +26,7 @@ from linebot.models import (
     LeaveEvent, PostbackEvent, BeaconEvent,
     TextMessage, ImageMessage, VideoMessage, AudioMessage,
     LocationMessage, StickerMessage,
-    SourceUser, SourceRoom, SourceGroup,
-    Params,
+    SourceUser, SourceRoom, SourceGroup
 )
 
 
@@ -266,8 +265,7 @@ class TestWebhookParser(unittest.TestCase):
         self.assertEqual(events[15].source.user_id, 'U206d25c2ea6bd87c17655609a1c37cb8')
         self.assertEqual(events[15].source.sender_id, 'U206d25c2ea6bd87c17655609a1c37cb8')
         self.assertEqual(events[15].postback.data, 'action=buyItem&itemId=123123&color=red')
-        self.assertIsInstance(events[15].postback.params, Params)
-        self.assertEqual(events[15].postback.params.date, '2013-04-01')
+        self.assertEqual(events[15].postback.params['date'], '2013-04-01')
 
         # PostbackEvent, SourceUser, with date params
         self.assertIsInstance(events[16], PostbackEvent)
@@ -279,8 +277,7 @@ class TestWebhookParser(unittest.TestCase):
         self.assertEqual(events[16].source.user_id, 'U206d25c2ea6bd87c17655609a1c37cb8')
         self.assertEqual(events[16].source.sender_id, 'U206d25c2ea6bd87c17655609a1c37cb8')
         self.assertEqual(events[16].postback.data, 'action=buyItem&itemId=123123&color=red')
-        self.assertIsInstance(events[15].postback.params, Params)
-        self.assertEqual(events[16].postback.params.time, '10:00')
+        self.assertEqual(events[16].postback.params['time'], '10:00')
 
         # PostbackEvent, SourceUser, with date params
         self.assertIsInstance(events[17], PostbackEvent)
@@ -292,8 +289,7 @@ class TestWebhookParser(unittest.TestCase):
         self.assertEqual(events[17].source.user_id, 'U206d25c2ea6bd87c17655609a1c37cb8')
         self.assertEqual(events[17].source.sender_id, 'U206d25c2ea6bd87c17655609a1c37cb8')
         self.assertEqual(events[17].postback.data, 'action=buyItem&itemId=123123&color=red')
-        self.assertIsInstance(events[15].postback.params, Params)
-        self.assertEqual(events[17].postback.params.datetime, '2013-04-01T10:00')
+        self.assertEqual(events[17].postback.params['datetime'], '2013-04-01T10:00')
 
 
 class TestWebhookHandler(unittest.TestCase):


### PR DESCRIPTION
There is a possibility that new values will be added to `postback.param` from now on.
To support flexibly, use `dict` instead of dedicated objects.