### PR TITLE
Fix arg_parser option for examples

### DIFF
--- a/examples/flask-echo/app.py
+++ b/examples/flask-echo/app.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     arg_parser = ArgumentParser(
         usage='Usage: python ' + __file__ + ' [--port <port>] [--help]'
     )
-    arg_parser.add_argument('-p', '--port', default=8000, help='port')
+    arg_parser.add_argument('-p', '--port', type=int, default=8000, help='port')
     arg_parser.add_argument('-d', '--debug', default=False, help='debug')
     options = arg_parser.parse_args()
 

--- a/examples/flask-kitchensink/app.py
+++ b/examples/flask-kitchensink/app.py
@@ -299,7 +299,7 @@ if __name__ == "__main__":
     arg_parser = ArgumentParser(
         usage='Usage: python ' + __file__ + ' [--port <port>] [--help]'
     )
-    arg_parser.add_argument('-p', '--port', default=8000, help='port')
+    arg_parser.add_argument('-p', '--port', type=int, default=8000, help='port')
     arg_parser.add_argument('-d', '--debug', default=False, help='debug')
     options = arg_parser.parse_args()
 

--- a/examples/simple-server-echo/app.py
+++ b/examples/simple-server-echo/app.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     arg_parser = ArgumentParser(
         usage='Usage: python ' + __file__ + ' [--port <port>] [--help]'
     )
-    arg_parser.add_argument('-p', '--port', default=8000, help='port')
+    arg_parser.add_argument('-p', '--port', type=int, default=8000, help='port')
     options = arg_parser.parse_args()
 
     httpd = wsgiref.simple_server.make_server('', options.port, application)


### PR DESCRIPTION
The following bug was found.

```bash
$ cd examples/flask-echo/
$ export LINE_CHANNEL_SECRET=foo
$ export LINE_CHANNEL_ACCESS_TOKEN=bar
$ pip install -r requirements.txt
$ python app.py --port 4000
Traceback (most recent call last):
  File "app.py", line 85, in <module>
    app.run(debug=options.debug, port=options.port)
  File "/home/xxx/line_env/local/lib/python2.7/site-packages/flask/app.py", line 841, in run
    run_simple(host, port, self, **options)
  File "/home/xxx/line_env/local/lib/python2.7/site-packages/werkzeug/serving.py", line 733, in run_simple
    raise TypeError('port must be an integer')
TypeError: port must be an integer
```