### PR TITLE
Remove py33 from tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, py36-flake8-src, py36-flake8-other
+envlist = py27, py34, py35, py36, py36-flake8-src, py36-flake8-other
 
 [testenv]
 deps =


### PR DESCRIPTION
Recent pytest releases (3.3.x) no longer support Python 3.3.
So, CI for https://github.com/line/line-bot-sdk-python/pull/87 & https://github.com/line/line-bot-sdk-python/pull/82 failed.
How about removing py3.3 from tox.ini?

pytest's Changelog: https://docs.pytest.org/en/latest/changelog.html
refs: https://github.com/pytest-dev/pytest/pull/2928/files

```bash
$ tox
...
Collecting pytest (from -r /home/xxx/line_env/line-bot-sdk-python/requirements-test.txt (line 1)) 
  Using cached pytest-3.3.1-py2.py3-none-any.whl    
pytest requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*' but the running Python is 3.3.7       

ERROR: could not install deps [six, -r/home/xxx/line_env/line-bot-sdk-python/requirements.txt, -r/home/xxx/line_env/line-bot-sdk-python/requirements-test.txt]; v = InvocationError('/home/xxx/line_env/line-bot-sdk-python/.tox/py33/bin/pip install six -r/home/xxx/line_env/line-bot-sdk-python/requirements.txt -r/home/xxx/line_env/line-bot-sdk-python/requirements-test.txt (see /home/xxx/line_env/line-bot-sdk-python/.tox/py33/log/py33-1.log)', 1)  
```