### PR TITLE
Remove py33 from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -702,7 +702,7 @@ OR |Documentation Status|
 Requirements
 ------------
 
--  Python >= 2.7 or >= 3.3
+-  Python >= 2.7 or >= 3.4
 
 For SDK developers
 ------------------
@@ -719,7 +719,6 @@ Run tests
 Test by using tox. We test against the following versions.
 
 -  2.7
--  3.3
 -  3.4
 -  3.5
 -  3.6


### PR DESCRIPTION
Trivial, but https://github.com/line/line-bot-sdk-python/pull/88 didn't include this. I forgot to mention this before you merged https://github.com/line/line-bot-sdk-python/pull/82 :)