### PR TITLE
Add dependency "pydocstyle<4"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     six
     flake8
     flake8-docstrings
+    pydocstyle<4
 commands = flake8 linebot/
 
 [testenv:py37-flake8-other]


### PR DESCRIPTION
https://github.com/PyCQA/pydocstyle/issues/375

Add dependency `pydocstyle<4` until `flake8-docstrings` is updated.