### PR TITLE
flask-kitchensink: Specify werkzeug version

### DIFF
--- a/examples/flask-kitchensink/requirements.txt
+++ b/examples/flask-kitchensink/requirements.txt
@@ -1,3 +1,3 @@
 line-bot-sdk
 flask
-werkzeug
+werkzeug>=0.15.4


### PR DESCRIPTION
ProxyFix package is only available after 0.15.0 release.
https://werkzeug.palletsprojects.com/en/0.15.x/changes/#version-0-15-4