### PR TITLE
Remove dependency `pydocstyle<4`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ deps =
     six
     flake8
     flake8-docstrings
-    pydocstyle<4
 commands = flake8 linebot/
 
 [testenv:py37-flake8-other]


### PR DESCRIPTION
- #199
- https://gitlab.com/pycqa/flake8-docstrings/issues/36