### PR TITLE
Define response object for broadcast api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Create a new LineBotApi instance.
 You can override the ``timeout`` value for each method.
 
 reply\_message(self, reply\_token, messages, notification_disabled=False, timeout=None)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Respond to events from users, groups, and rooms. You can get a
 reply\_token from a webhook event object.
@@ -126,9 +126,9 @@ https://developers.line.biz/en/reference/messaging-api/#send-push-message
     line_bot_api.push_message(to, TextSendMessage(text='Hello World!'))
 
 multicast(self, to, messages, notification_disabled=False, timeout=None)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sends push messages to multiple users at any time. Messages cannot be sent to groups or rooms.
+Send push messages to multiple users at any time. Messages cannot be sent to groups or rooms.
 
 https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
 
@@ -139,7 +139,7 @@ https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
 broadcast(self, messages, notification_disabled=False, timeout=None)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sends push messages to multiple users at any time.
+Send push messages to multiple users at any time.
 
 https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
 
@@ -472,7 +472,7 @@ https://developers.line.biz/en/reference/messaging-api/#revoke-channel-access-to
     line_bot_api.revoke_channel_token(<access_token>)
 
 get\_insight\_message\_delivery(self, date, timeout=None)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Get the number of messages sent on a specified day.
 
@@ -484,7 +484,7 @@ https://developers.line.biz/en/reference/messaging-api/#get-number-of-delivery-m
     print(insight.api_broadcast)
 
 get\_insight\_followers(self, date, timeout=None)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Get the number of users who have added the bot on or before a specified date.
 
@@ -496,7 +496,7 @@ https://developers.line.biz/en/reference/messaging-api/#get-number-of-followers
     print(insight.followers)
 
 get\_insight\_demographic(self, timeout=None)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Retrieve the demographic attributes for a bot's friends.
 
@@ -521,7 +521,7 @@ https://developers.line.biz/en/reference/messaging-api/#get-message-event
     print(insight.overview)
 
 ※ Error handling
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 If the LINE API server returns an error, LineBotApi raises LineBotApiError.
 

--- a/README.rst
+++ b/README.rst
@@ -102,8 +102,8 @@ Create a new LineBotApi instance.
 
 You can override the ``timeout`` value for each method.
 
-reply\_message(self, reply\_token, messages, timeout=None)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+reply\_message(self, reply\_token, messages, notification_disabled=False, timeout=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Respond to events from users, groups, and rooms. You can get a
 reply\_token from a webhook event object.
@@ -114,8 +114,8 @@ https://developers.line.biz/en/reference/messaging-api/#send-reply-message
 
     line_bot_api.reply_message(reply_token, TextSendMessage(text='Hello World!'))
 
-push\_message(self, to, messages, timeout=None)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+push\_message(self, to, messages, notification_disabled=False, timeout=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Send messages to users, groups, and rooms at any time.
 
@@ -125,16 +125,27 @@ https://developers.line.biz/en/reference/messaging-api/#send-push-message
 
     line_bot_api.push_message(to, TextSendMessage(text='Hello World!'))
 
-multicast(self, to, messages, timeout=None)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+multicast(self, to, messages, notification_disabled=False, timeout=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Send messages to multiple users at any time.
+Sends push messages to multiple users at any time. Messages cannot be sent to groups or rooms.
 
 https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
 
 .. code:: python
 
     line_bot_api.multicast(['to1', 'to2'], TextSendMessage(text='Hello World!'))
+
+broadcast(self, messages, notification_disabled=False, timeout=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sends push messages to multiple users at any time.
+
+https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
+
+.. code:: python
+
+    line_bot_api.broadcast(TextSendMessage(text='Hello World!'))
 
 get\_profile(self, user\_id, timeout=None)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -505,7 +516,8 @@ https://developers.line.biz/en/reference/messaging-api/#get-message-event
 
 .. code:: python
 
-    insight = line_bot_api.get_insight_message_event()
+    broadcast_response = line_bot_api.broadcast(TextSendMessage(text='Hello World!'))
+    insight = line_bot_api.get_insight_message_event(broadcast_response.request_id)
     print(insight.overview)
 
 ※ Error handling

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -145,7 +145,7 @@ class LineBotApi(object):
 
         https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
 
-        Send messages to multiple users at any time.
+        Sends push messages to multiple users at any time. Messages cannot be sent to groups or rooms.
 
         :param to: IDs of the receivers
             Max: 150 users
@@ -180,7 +180,7 @@ class LineBotApi(object):
 
         https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
 
-        Send messages to multiple users at any time.
+        Sends push messages to multiple users at any time.
 
         :param messages: Messages.
             Max: 5

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -27,7 +27,8 @@ from .models import (
     MessageDeliveryBroadcastResponse, MessageDeliveryMulticastResponse,
     MessageDeliveryPushResponse, MessageDeliveryReplyResponse,
     InsightMessageDeliveryResponse, InsightFollowersResponse, InsightDemographicResponse,
-    InsightMessageEventResponse,
+    InsightMessageEventResponse, ReplyMessageResponse, PushMessageResponse,
+    MultiCastResponse, BroadCastResponse,
 )
 
 
@@ -103,9 +104,11 @@ class LineBotApi(object):
             'notificationDisabled': notification_disabled,
         }
 
-        self._post(
+        response = self._post(
             '/v2/bot/message/reply', data=json.dumps(data), timeout=timeout
         )
+
+        return ReplyMessageResponse(response=response)
 
     def push_message(self, to, messages, notification_disabled=False, timeout=None):
         """Call push message API.
@@ -136,9 +139,11 @@ class LineBotApi(object):
             'notificationDisabled': notification_disabled,
         }
 
-        self._post(
+        response = self._post(
             '/v2/bot/message/push', data=json.dumps(data), timeout=timeout
         )
+
+        return PushMessageResponse(response=response)
 
     def multicast(self, to, messages, notification_disabled=False, timeout=None):
         """Call multicast API.
@@ -171,9 +176,11 @@ class LineBotApi(object):
             'notificationDisabled': notification_disabled,
         }
 
-        self._post(
+        response = self._post(
             '/v2/bot/message/multicast', data=json.dumps(data), timeout=timeout
         )
+
+        return MultiCastResponse(response=response)
 
     def broadcast(self, messages, notification_disabled=False, timeout=None):
         """Call broadcast API.
@@ -202,9 +209,11 @@ class LineBotApi(object):
             'notificationDisabled': notification_disabled,
         }
 
-        self._post(
+        response = self._post(
             '/v2/bot/message/broadcast', data=json.dumps(data), timeout=timeout
         )
+
+        return BroadCastResponse(response=response)
 
     def get_message_delivery_broadcast(self, date, timeout=None):
         """Get number of sent broadcast messages.

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -27,8 +27,7 @@ from .models import (
     MessageDeliveryBroadcastResponse, MessageDeliveryMulticastResponse,
     MessageDeliveryPushResponse, MessageDeliveryReplyResponse,
     InsightMessageDeliveryResponse, InsightFollowersResponse, InsightDemographicResponse,
-    InsightMessageEventResponse, ReplyMessageResponse, PushMessageResponse,
-    MultiCastResponse, BroadCastResponse,
+    InsightMessageEventResponse, BroadCastResponse,
 )
 
 
@@ -104,11 +103,9 @@ class LineBotApi(object):
             'notificationDisabled': notification_disabled,
         }
 
-        response = self._post(
+        self._post(
             '/v2/bot/message/reply', data=json.dumps(data), timeout=timeout
         )
-
-        return ReplyMessageResponse(response=response)
 
     def push_message(self, to, messages, notification_disabled=False, timeout=None):
         """Call push message API.
@@ -139,11 +136,9 @@ class LineBotApi(object):
             'notificationDisabled': notification_disabled,
         }
 
-        response = self._post(
+        self._post(
             '/v2/bot/message/push', data=json.dumps(data), timeout=timeout
         )
-
-        return PushMessageResponse(response=response)
 
     def multicast(self, to, messages, notification_disabled=False, timeout=None):
         """Call multicast API.
@@ -176,11 +171,9 @@ class LineBotApi(object):
             'notificationDisabled': notification_disabled,
         }
 
-        response = self._post(
+        self._post(
             '/v2/bot/message/multicast', data=json.dumps(data), timeout=timeout
         )
-
-        return MultiCastResponse(response=response)
 
     def broadcast(self, messages, notification_disabled=False, timeout=None):
         """Call broadcast API.
@@ -213,7 +206,7 @@ class LineBotApi(object):
             '/v2/bot/message/broadcast', data=json.dumps(data), timeout=timeout
         )
 
-        return BroadCastResponse(response=response)
+        return BroadCastResponse(request_id=response.headers.get('X-Line-Request-Id'))
 
     def get_message_delivery_broadcast(self, date, timeout=None):
         """Get number of sent broadcast messages.
@@ -940,7 +933,6 @@ class LineBotApi(object):
 
         https://developers.line.biz/en/reference/messaging-api/#get-demographic
 
-        :param str date: Date for which to retrieve the number of followers.
         :param timeout: (optional) How long to wait for the server
             to send data before giving up, as a float,
             or a (connect timeout, read timeout) float tuple.

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -27,7 +27,7 @@ from .models import (
     MessageDeliveryBroadcastResponse, MessageDeliveryMulticastResponse,
     MessageDeliveryPushResponse, MessageDeliveryReplyResponse,
     InsightMessageDeliveryResponse, InsightFollowersResponse, InsightDemographicResponse,
-    InsightMessageEventResponse, BroadCastResponse,
+    InsightMessageEventResponse, BroadcastResponse,
 )
 
 
@@ -207,7 +207,7 @@ class LineBotApi(object):
             '/v2/bot/message/broadcast', data=json.dumps(data), timeout=timeout
         )
 
-        return BroadCastResponse(request_id=response.headers.get('X-Line-Request-Id'))
+        return BroadcastResponse(request_id=response.headers.get('X-Line-Request-Id'))
 
     def get_message_delivery_broadcast(self, date, timeout=None):
         """Get number of sent broadcast messages.

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -145,7 +145,8 @@ class LineBotApi(object):
 
         https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
 
-        Sends push messages to multiple users at any time. Messages cannot be sent to groups or rooms.
+        Sends push messages to multiple users at any time.
+        Messages cannot be sent to groups or rooms.
 
         :param to: IDs of the receivers
             Max: 150 users

--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -121,6 +121,10 @@ from .responses import (  # noqa
     InsightFollowersResponse,
     InsightDemographicResponse,
     InsightMessageEventResponse,
+    ReplyMessageResponse,
+    PushMessageResponse,
+    BroadCastResponse,
+    MultiCastResponse,
 )
 from .rich_menu import (  # noqa
     RichMenu,

--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -121,10 +121,7 @@ from .responses import (  # noqa
     InsightFollowersResponse,
     InsightDemographicResponse,
     InsightMessageEventResponse,
-    ReplyMessageResponse,
-    PushMessageResponse,
     BroadCastResponse,
-    MultiCastResponse,
 )
 from .rich_menu import (  # noqa
     RichMenu,

--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -121,7 +121,7 @@ from .responses import (  # noqa
     InsightFollowersResponse,
     InsightDemographicResponse,
     InsightMessageEventResponse,
-    BroadCastResponse,
+    BroadcastResponse,
 )
 from .rich_menu import (  # noqa
     RichMenu,

--- a/linebot/models/responses.py
+++ b/linebot/models/responses.py
@@ -25,6 +25,66 @@ from .insight import (
 from .rich_menu import RichMenuSize, RichMenuArea
 
 
+class ReplyMessageResponse(object):
+    """ReplyMessageResponse.
+
+    https://developers.line.biz/en/reference/messaging-api/#send-reply-message
+    """
+
+    def __init__(self, response):
+        """__init__ method.
+
+        :param response: HttpResponse object
+        :type response: T <= :py:class:`linebot.http_client.HttpResponse`
+        """
+        self.response = response
+
+
+class PushMessageResponse(object):
+    """PushMessageResponse.
+
+    https://developers.line.biz/en/reference/messaging-api/#send-push-message
+    """
+
+    def __init__(self, response):
+        """__init__ method.
+
+        :param response: HttpResponse object
+        :type response: T <= :py:class:`linebot.http_client.HttpResponse`
+        """
+        self.response = response
+
+
+class MultiCastResponse(object):
+    """MultiCastResponse.
+
+    https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
+    """
+
+    def __init__(self, response):
+        """__init__ method.
+
+        :param response: HttpResponse object
+        :type response: T <= :py:class:`linebot.http_client.HttpResponse`
+        """
+        self.response = response
+
+
+class BroadCastResponse(object):
+    """BroadCastResponse.
+
+    https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
+    """
+
+    def __init__(self, response):
+        """__init__ method.
+
+        :param response: HttpResponse object
+        :type response: T <= :py:class:`linebot.http_client.HttpResponse`
+        """
+        self.response = response
+
+
 class Profile(Base):
     """Profile.
 

--- a/linebot/models/responses.py
+++ b/linebot/models/responses.py
@@ -25,8 +25,8 @@ from .insight import (
 from .rich_menu import RichMenuSize, RichMenuArea
 
 
-class BroadCastResponse(object):
-    """BroadCastResponse.
+class BroadcastResponse(object):
+    """BroadcastResponse.
 
     https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
     """

--- a/linebot/models/responses.py
+++ b/linebot/models/responses.py
@@ -25,64 +25,18 @@ from .insight import (
 from .rich_menu import RichMenuSize, RichMenuArea
 
 
-class ReplyMessageResponse(object):
-    """ReplyMessageResponse.
-
-    https://developers.line.biz/en/reference/messaging-api/#send-reply-message
-    """
-
-    def __init__(self, response):
-        """__init__ method.
-
-        :param response: HttpResponse object
-        :type response: T <= :py:class:`linebot.http_client.HttpResponse`
-        """
-        self.response = response
-
-
-class PushMessageResponse(object):
-    """PushMessageResponse.
-
-    https://developers.line.biz/en/reference/messaging-api/#send-push-message
-    """
-
-    def __init__(self, response):
-        """__init__ method.
-
-        :param response: HttpResponse object
-        :type response: T <= :py:class:`linebot.http_client.HttpResponse`
-        """
-        self.response = response
-
-
-class MultiCastResponse(object):
-    """MultiCastResponse.
-
-    https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
-    """
-
-    def __init__(self, response):
-        """__init__ method.
-
-        :param response: HttpResponse object
-        :type response: T <= :py:class:`linebot.http_client.HttpResponse`
-        """
-        self.response = response
-
-
 class BroadCastResponse(object):
     """BroadCastResponse.
 
     https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
     """
 
-    def __init__(self, response):
+    def __init__(self, request_id=None):
         """__init__ method.
 
-        :param response: HttpResponse object
-        :type response: T <= :py:class:`linebot.http_client.HttpResponse`
+        :param str request_id: Request ID. A unique ID is generated for each request
         """
-        self.response = response
+        self.request_id = request_id
 
 
 class Profile(Base):

--- a/tests/api/test_send_text_message.py
+++ b/tests/api/test_send_text_message.py
@@ -115,7 +115,7 @@ class TestSendTestMessage(unittest.TestCase):
             json={}, status=200, headers={'X-Line-Request-Id': 'request_id_test'}
         )
 
-        self.tested.broadcast(self.text_message)
+        response = self.tested.broadcast(self.text_message)
 
         request = responses.calls[0].request
         self.assertEqual(

--- a/tests/api/test_send_text_message.py
+++ b/tests/api/test_send_text_message.py
@@ -129,6 +129,7 @@ class TestSendTestMessage(unittest.TestCase):
                 "messages": self.message
             }
         )
+        self.assertEqual('request_id_test', response.request_id)
 
         # call with notification_disable=True
         response = self.tested.broadcast(self.text_message, notification_disabled=True)

--- a/tests/api/test_send_text_message.py
+++ b/tests/api/test_send_text_message.py
@@ -112,7 +112,7 @@ class TestSendTestMessage(unittest.TestCase):
         responses.add(
             responses.POST,
             LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/message/broadcast',
-            json={}, status=200
+            json={}, status=200, headers={'X-Line-Request-Id': 'request_id_test'}
         )
 
         self.tested.broadcast(self.text_message)
@@ -131,7 +131,7 @@ class TestSendTestMessage(unittest.TestCase):
         )
 
         # call with notification_disable=True
-        self.tested.broadcast(self.text_message, notification_disabled=True)
+        response = self.tested.broadcast(self.text_message, notification_disabled=True)
 
         request = responses.calls[1].request
         self.assertEqual(
@@ -145,6 +145,7 @@ class TestSendTestMessage(unittest.TestCase):
                 "messages": self.message
             }
         )
+        self.assertEqual('request_id_test', response.request_id)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`broadcast` returns response object which contains `X-Line-Request-Id`.

related: #215, #220