### PR TITLE
Fix contents parameter reassignment

### DIFF
--- a/linebot/models/flex_message.py
+++ b/linebot/models/flex_message.py
@@ -46,7 +46,6 @@ class FlexSendMessage(SendMessage):
 
         self.type = 'flex'
         self.alt_text = alt_text
-        self.contents = contents
         self.contents = self.get_or_new_from_json_dict_with_types(
             contents, {
                 'bubble': BubbleContainer,


### PR DESCRIPTION
Remove `self.contents = contents` from `FlexSendMessage.__init__` method because it isn't used  before assign it again