### PR TITLE
Add narrowcast client api

### DIFF
--- a/linebot/api.py
+++ b/linebot/api.py
@@ -454,6 +454,33 @@ class LineBotApi(object):
 
         return Content(response)
 
+    def narrowcast(self, messages, recipient=None, filter=None, limit=None, timeout=None):
+        """Narrowcast messages to users
+
+        https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message
+
+        :param messages: List
+        :param recipient: (optional): Object
+        :param filter: (optional): Object
+        :param limit: (optional): Number
+        :param timeout: (optional) How long to wait for the server
+            to send data before giving up, as a float,
+            or a (connect timeout, read timeout) float tuple.
+            Default is self.http_client.timeout
+        :type timeout: float | tuple(float, float)
+        """
+
+        self._post(
+            '/v2/bot/message/narrowcast',
+            data=json.dumps({
+                'messages': messages,
+                'recipient': recipient,
+                'filter': filter,
+                'limit': limit,
+            }),
+            timeout=timeout
+        )
+
     def leave_group(self, group_id, timeout=None):
         """Call leave group API.
 

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -17,6 +17,7 @@
 from __future__ import unicode_literals
 
 import json
+import re
 
 from .__about__ import __version__
 from .exceptions import LineBotApiError
@@ -27,7 +28,7 @@ from .models import (
     MessageDeliveryBroadcastResponse, MessageDeliveryMulticastResponse,
     MessageDeliveryPushResponse, MessageDeliveryReplyResponse,
     InsightMessageDeliveryResponse, InsightFollowersResponse, InsightDemographicResponse,
-    InsightMessageEventResponse, BroadcastResponse,
+    InsightMessageEventResponse, BroadcastResponse, NarrowCastModel
 )
 
 
@@ -469,14 +470,23 @@ class LineBotApi(object):
             Default is self.http_client.timeout
         :type timeout: float | tuple(float, float)
         """
+        asd = NarrowCastModel.new_from_json_dict({
+            'messages': messages,
+            'recipient': recipient,
+            'filter': filter,
+            'limit': limit
+        })
+        output = json.dumps(asd.as_json_dict())
+        if '"AND": ' in output:
+            output = re.sub('\"AND\":', '\"and\":', output)
+        if '"OR": ' in output:
+            output = re.sub('\"OR\":', '\"or\":', output)
+        if '"NOT": ' in output:
+            output = re.sub('\"NOT\":', '\"not\":', output)
+
         self._post(
             '/v2/bot/message/narrowcast',
-            data=json.dumps({
-                'messages': messages,
-                'recipient': recipient,
-                'filter': filter,
-                'limit': limit,
-            }),
+            data=output,
             timeout=timeout
         )
 

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -455,7 +455,7 @@ class LineBotApi(object):
         return Content(response)
 
     def narrowcast(self, messages, recipient=None, filter=None, limit=None, timeout=None):
-        """Narrowcast messages to users
+        """Narrowcast messages to users.
 
         https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message
 
@@ -469,7 +469,6 @@ class LineBotApi(object):
             Default is self.http_client.timeout
         :type timeout: float | tuple(float, float)
         """
-
         self._post(
             '/v2/bot/message/narrowcast',
             data=json.dumps({

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -470,13 +470,13 @@ class LineBotApi(object):
             Default is self.http_client.timeout
         :type timeout: float | tuple(float, float)
         """
-        asd = NarrowCastModel.new_from_json_dict({
+        narrowcast = NarrowCastModel.new_from_json_dict({
             'messages': messages,
             'recipient': recipient,
             'filter': filter,
             'limit': limit
         })
-        output = json.dumps(asd.as_json_dict())
+        output = json.dumps(narrowcast.as_json_dict())
         if '"AND": ' in output:
             output = re.sub('\"AND\":', '\"and\":', output)
         if '"OR": ' in output:

--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -163,3 +163,7 @@ from .things import (  # noqa
     ActionResult,
     Things,
 )
+
+from .narrowcast import (
+    NarrowCastModel
+)

--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -164,6 +164,6 @@ from .things import (  # noqa
     Things,
 )
 
-from .narrowcast import (
+from .narrowcast import (  # noqa
     NarrowCastModel
 )

--- a/linebot/models/narrowcast.py
+++ b/linebot/models/narrowcast.py
@@ -12,16 +12,27 @@
 #  License for the specific language governing permissions and limitations
 #  under the License.
 
+"""linebot.models.narrowcast module."""
 
 from __future__ import unicode_literals
 
 from functools import wraps
 
-from .base import Base
+from .send_messages import SendMessage
 
 
-class NarrowCastModel(Base):
+class NarrowCastModel(SendMessage):
+    """Model."""
+
     def __init__(self, messages, recipient=None, filter=None, limit=None, **kwargs):
+        """__init__ method.
+
+        :param messages: List of messages to send.
+        :param: recipient: filter condition
+        :param: filter: filter condition
+        :param: limit: Limit of send messages count.
+        :param kwargs:
+        """
         super(NarrowCastModel, self).__init__(**kwargs)
         self.messages = messages
         self.recipient = self.get_or_new_from_json_dict_with_types(
@@ -39,8 +50,15 @@ class NarrowCastModel(Base):
         self.limit = self.get_or_new_from_json_dict(limit, NarrowCastLimit)
 
 
-class NarrowCastDemographic(Base):
+class NarrowCastDemographic(SendMessage):
+    """Demographic."""
+
     def __init__(self, demographic=None, **kwargs):
+        """__init__ method.
+
+        :param demographic: dict
+        :param kwargs:
+        """
         super(NarrowCastDemographic, self).__init__(**kwargs)
         self.demographic = self.get_or_new_from_json_dict_with_types(
             demographic, {
@@ -55,7 +73,7 @@ class NarrowCastDemographic(Base):
         )
 
 
-class NarrowCastLimit(Base):
+class NarrowCastLimit(SendMessage):
     """Limit."""
 
     def __init__(self, max=None, **kwargs):
@@ -67,25 +85,9 @@ class NarrowCastLimit(Base):
         self.max = max
 
 
-class NarrowCast(Base):
-    """NarrowCast.
-
-    https://developers.line.biz/en/reference/messaging-api/#container
-
-    A container is the top-level structure of a Flex Message.
-    """
-
-    def __init__(self, **kwargs):
-        """__init__ method.
-
-        :param kwargs:
-        """
-        super(NarrowCast, self).__init__(**kwargs)
-
-        self.type = None
-
-
 def operator_initialize(func):
+    """Give a function to judge and UPPER operator."""
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         if kwargs.get('and'):
@@ -99,11 +101,18 @@ def operator_initialize(func):
     return wrapper
 
 
-class Operator(NarrowCast):
+class Operator(SendMessage):
     """Operator."""
 
     @operator_initialize
     def __init__(self, AND=None, OR=None, NOT=None, **kwargs):
+        """__init__ method.
+
+        :param AND: Upper of operator 'and'
+        :param OR: Upper of operator 'or'
+        :param NOT: Upper of operator 'not'
+        :param kwargs:
+        """
         super(Operator, self).__init__(**kwargs)
         self.type = 'operator'
         new_and = []
@@ -149,57 +158,89 @@ class Operator(NarrowCast):
         )
 
 
-class Audience(NarrowCast):
+class Audience(SendMessage):
     """Audience."""
 
-    def __init__(self, audience_group_id=None, request_id=None, **kwargs):
+    def __init__(self, audience_group_id=None, **kwargs):
+        """__init__ method.
+
+        :param audience_group_id: group_id
+        :param kwargs:
+        """
         super(Audience, self).__init__(**kwargs)
 
         self.type = 'audience'
         self.audience_group_id = audience_group_id
 
 
-class Age(NarrowCast):
+class Age(SendMessage):
     """Age."""
 
     def __init__(self, gte=None, lt=None, **kwargs):
+        """__init__ method.
+
+        :param gte: Above designated age
+        :param lt: Under designated age
+        :param kwargs:
+        """
         super(Age, self).__init__(**kwargs)
         self.type = 'age'
         self.gte = gte
         self.lt = lt
 
 
-class Gender(NarrowCast):
+class Gender(SendMessage):
     """Gender."""
 
     def __init__(self, one_of=None, **kwargs):
+        """__init__ method.
+
+        :param one_of: Gender list
+        :param kwargs:
+        """
         super(Gender, self).__init__(**kwargs)
         self.type = 'gender'
         self.one_of = one_of
 
 
-class App(NarrowCast):
+class App(SendMessage):
     """App."""
 
     def __init__(self, one_of=None, **kwargs):
+        """__init__ method.
+
+        :param one_of: List of mobile OS
+        :param kwargs:
+        """
         super(App, self).__init__(**kwargs)
         self.type = 'appType'
         self.one_of = one_of
 
 
-class Area(NarrowCast):
+class Area(SendMessage):
     """Area."""
 
     def __init__(self, one_of=None, **kwargs):
+        """__init__ method.
+
+        :param one_of: List of area
+        :param kwargs:
+        """
         super(Area, self).__init__(**kwargs)
         self.type = 'area'
         self.one_of = one_of
 
 
-class SubscriptionPeriod(NarrowCast):
+class SubscriptionPeriod(SendMessage):
     """SubscriptionPeriod."""
 
     def __init__(self, gte=None, lt=None, **kwargs):
+        """__init__ method.
+
+        :param gte:
+        :param lt:
+        :param kwargs:
+        """
         super(SubscriptionPeriod, self).__init__(**kwargs)
         self.type = 'subscriptionPeriod'
         self.gte = gte

--- a/linebot/models/narrowcast.py
+++ b/linebot/models/narrowcast.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+
+from __future__ import unicode_literals
+
+from functools import wraps
+
+from .base import Base
+
+
+class NarrowCastModel(Base):
+    def __init__(self, messages, recipient=None, filter=None, limit=None, **kwargs):
+        super(NarrowCastModel, self).__init__(**kwargs)
+        self.messages = messages
+        self.recipient = self.get_or_new_from_json_dict_with_types(
+            recipient, {
+                'operator': Operator,
+                'audience': Audience,
+                'gender': Gender,
+                'age': Age,
+                'appType': App,
+                'area': Area,
+                'subscriptionPeriod': SubscriptionPeriod
+            }
+        )
+        self.filter = self.get_or_new_from_json_dict(filter, NarrowCastDemographic)
+        self.limit = self.get_or_new_from_json_dict(limit, NarrowCastLimit)
+
+
+class NarrowCastDemographic(Base):
+    def __init__(self, demographic=None, **kwargs):
+        super(NarrowCastDemographic, self).__init__(**kwargs)
+        self.demographic = self.get_or_new_from_json_dict_with_types(
+            demographic, {
+                'operator': Operator,
+                'audience': Audience,
+                'gender': Gender,
+                'age': Age,
+                'appType': App,
+                'area': Area,
+                'subscriptionPeriod': SubscriptionPeriod
+            }
+        )
+
+
+class NarrowCastLimit(Base):
+    """Limit."""
+
+    def __init__(self, max=None, **kwargs):
+        """__init__ method.
+
+        :param int max: Limit of send message.
+        """
+        super(NarrowCastLimit, self).__init__(**kwargs)
+        self.max = max
+
+
+class NarrowCast(Base):
+    """NarrowCast.
+
+    https://developers.line.biz/en/reference/messaging-api/#container
+
+    A container is the top-level structure of a Flex Message.
+    """
+
+    def __init__(self, **kwargs):
+        """__init__ method.
+
+        :param kwargs:
+        """
+        super(NarrowCast, self).__init__(**kwargs)
+
+        self.type = None
+
+
+def operator_initialize(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if kwargs.get('and'):
+            kwargs['AND'] = kwargs['and']
+        if kwargs.get('or'):
+            kwargs['OR'] = kwargs['or']
+        if kwargs.get('not'):
+            kwargs['NOT'] = kwargs['not']
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+class Operator(NarrowCast):
+    """Operator."""
+
+    @operator_initialize
+    def __init__(self, AND=None, OR=None, NOT=None, **kwargs):
+        super(Operator, self).__init__(**kwargs)
+        self.type = 'operator'
+        new_and = []
+        if AND:
+            for condition in AND:
+                new_and.append(self.get_or_new_from_json_dict_with_types(
+                    condition, {
+                        'operator': Operator,
+                        'audience': Audience,
+                        'gender': Gender,
+                        'age': Age,
+                        'appType': App,
+                        'area': Area,
+                        'subscriptionPeriod': SubscriptionPeriod
+                    }
+                ))
+        self.AND = new_and if new_and else None
+        new_or = []
+        if OR:
+            for condition in OR:
+                new_or.append(self.get_or_new_from_json_dict_with_types(
+                    condition, {
+                        'operator': Operator,
+                        'audience': Audience,
+                        'gender': Gender,
+                        'age': Age,
+                        'appType': App,
+                        'area': Area,
+                        'subscriptionPeriod': SubscriptionPeriod
+                    }
+                ))
+        self.OR = new_or if new_or else None
+
+        self.NOT = self.get_or_new_from_json_dict_with_types(
+            NOT, {
+                'audience': Audience,
+                'gender': Gender,
+                'age': Age,
+                'appType': App,
+                'area': Area,
+                'subscriptionPeriod': SubscriptionPeriod
+            }
+        )
+
+
+class Audience(NarrowCast):
+    """Audience."""
+
+    def __init__(self, audience_group_id=None, request_id=None, **kwargs):
+        super(Audience, self).__init__(**kwargs)
+
+        self.type = 'audience'
+        self.audience_group_id = audience_group_id
+
+
+class Age(NarrowCast):
+    """Age."""
+
+    def __init__(self, gte=None, lt=None, **kwargs):
+        super(Age, self).__init__(**kwargs)
+        self.type = 'age'
+        self.gte = gte
+        self.lt = lt
+
+
+class Gender(NarrowCast):
+    """Gender."""
+
+    def __init__(self, one_of=None, **kwargs):
+        super(Gender, self).__init__(**kwargs)
+        self.type = 'gender'
+        self.one_of = one_of
+
+
+class App(NarrowCast):
+    """App."""
+
+    def __init__(self, one_of=None, **kwargs):
+        super(App, self).__init__(**kwargs)
+        self.type = 'appType'
+        self.one_of = one_of
+
+
+class Area(NarrowCast):
+    """Area."""
+
+    def __init__(self, one_of=None, **kwargs):
+        super(Area, self).__init__(**kwargs)
+        self.type = 'area'
+        self.one_of = one_of
+
+
+class SubscriptionPeriod(NarrowCast):
+    """SubscriptionPeriod."""
+
+    def __init__(self, gte=None, lt=None, **kwargs):
+        super(SubscriptionPeriod, self).__init__(**kwargs)
+        self.type = 'subscriptionPeriod'
+        self.gte = gte
+        self.lt = lt

--- a/tests/api/test_narrowcast.py
+++ b/tests/api/test_narrowcast.py
@@ -1,0 +1,86 @@
+import json
+import unittest
+import responses
+
+from linebot import LineBotApi
+
+
+class TestLineBotApi(unittest.TestCase):
+	def setUp(self):
+		self.tested = LineBotApi('channel_secret')
+		self.endpoint = LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/message/narrowcast'
+		self.messages = [{
+			'type': 'text',
+			'text': 'Hello, world'
+		}]
+		self.recipient = None
+		self.filter = None
+		self.limit = None
+
+	@responses.activate
+	def test_narrowcast_text_message_without_condition(self):
+		expected = {
+			'messages': self.messages,
+			'recipient': self.recipient,
+			'filter': self.filter,
+			'limit': self.limit,
+		}
+		responses.add(
+			responses.POST,
+			self.endpoint,
+			json=expected,
+			status=202
+		)
+
+		self.tested.narrowcast(messages=self.messages)
+
+		request = responses.calls[0].request
+
+		self.assertEqual(request.method, 'POST')
+		self.assertEqual(request.url, self.endpoint)
+		self.assertEqual(request.body, json.dumps(expected))
+
+	@responses.activate
+	def test_narrowcast_text_message(self):
+		self.recipient = {
+			'type': "audience",
+			'audienceGroupId': 5614991017776
+		}
+		self.filter = {
+			'demographic': {
+				'type': "area",
+				'oneOf': [
+					"android"
+				]
+			}
+		}
+		self.limit = {'max': 100}
+		expected = {
+			'messages': self.messages,
+			'recipient': self.recipient,
+			'filter': self.filter,
+			'limit': self.limit,
+		}
+
+		responses.add(
+			responses.POST,
+			self.endpoint,
+			json=expected,
+			status=202
+		)
+
+		self.tested.narrowcast(
+			messages=self.messages,
+			recipient=self.recipient,
+			filter=self.filter,
+			limit=self.limit)
+
+		request = responses.calls[0].request
+
+		self.assertEqual(request.method, 'POST')
+		self.assertEqual(request.url, self.endpoint)
+		self.assertEqual(request.body, json.dumps(expected))
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/api/test_narrowcast.py
+++ b/tests/api/test_narrowcast.py
@@ -1,86 +1,85 @@
 import json
 import unittest
 import responses
-
 from linebot import LineBotApi
 
 
 class TestLineBotApi(unittest.TestCase):
-	def setUp(self):
-		self.tested = LineBotApi('channel_secret')
-		self.endpoint = LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/message/narrowcast'
-		self.messages = [{
-			'type': 'text',
-			'text': 'Hello, world'
-		}]
-		self.recipient = None
-		self.filter = None
-		self.limit = None
+    def setUp(self):
+        self.tested = LineBotApi('channel_secret')
+        self.endpoint = LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/message/narrowcast'
+        self.messages = [{
+            'type': 'text',
+            'text': 'Hello, world'
+        }]
+        self.recipient = None
+        self.filter = None
+        self.limit = None
 
-	@responses.activate
-	def test_narrowcast_text_message_without_condition(self):
-		expected = {
-			'messages': self.messages,
-			'recipient': self.recipient,
-			'filter': self.filter,
-			'limit': self.limit,
-		}
-		responses.add(
-			responses.POST,
-			self.endpoint,
-			json=expected,
-			status=202
-		)
+    @responses.activate
+    def test_narrowcast_text_message_without_condition(self):
+        expected = {
+            'messages': self.messages,
+            'recipient': self.recipient,
+            'filter': self.filter,
+            'limit': self.limit,
+        }
+        responses.add(
+            responses.POST,
+            self.endpoint,
+            json=expected,
+            status=202
+        )
 
-		self.tested.narrowcast(messages=self.messages)
+        self.tested.narrowcast(messages=self.messages)
 
-		request = responses.calls[0].request
+        request = responses.calls[0].request
 
-		self.assertEqual(request.method, 'POST')
-		self.assertEqual(request.url, self.endpoint)
-		self.assertEqual(request.body, json.dumps(expected))
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.url, self.endpoint)
+        self.assertEqual(request.body, json.dumps(expected))
 
-	@responses.activate
-	def test_narrowcast_text_message(self):
-		self.recipient = {
-			'type': "audience",
-			'audienceGroupId': 5614991017776
-		}
-		self.filter = {
-			'demographic': {
-				'type': "area",
-				'oneOf': [
-					"android"
-				]
-			}
-		}
-		self.limit = {'max': 100}
-		expected = {
-			'messages': self.messages,
-			'recipient': self.recipient,
-			'filter': self.filter,
-			'limit': self.limit,
-		}
+    @responses.activate
+    def test_narrowcast_text_message(self):
+        self.recipient = {
+            'type': "audience",
+            'audienceGroupId': 5614991017776
+        }
+        self.filter = {
+            'demographic': {
+                'type': "area",
+                'oneOf': [
+                    "android"
+                ]
+            }
+        }
+        self.limit = {'max': 100}
+        expected = {
+            'messages': self.messages,
+            'recipient': self.recipient,
+            'filter': self.filter,
+            'limit': self.limit,
+        }
 
-		responses.add(
-			responses.POST,
-			self.endpoint,
-			json=expected,
-			status=202
-		)
+        responses.add(
+            responses.POST,
+            self.endpoint,
+            json=expected,
+            status=202
+        )
 
-		self.tested.narrowcast(
-			messages=self.messages,
-			recipient=self.recipient,
-			filter=self.filter,
-			limit=self.limit)
+        self.tested.narrowcast(
+            messages=self.messages,
+            recipient=self.recipient,
+            filter=self.filter,
+            limit=self.limit)
 
-		request = responses.calls[0].request
+        request = responses.calls[0].request
 
-		self.assertEqual(request.method, 'POST')
-		self.assertEqual(request.url, self.endpoint)
-		self.assertEqual(request.body, json.dumps(expected))
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.url, self.endpoint)
+        self.assertEqual(request.body, json.dumps(expected))
 
 
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()

--- a/tests/api/test_narrowcast.py
+++ b/tests/api/test_narrowcast.py
@@ -25,8 +25,8 @@ class TestLineBotApi(unittest.TestCase):
         self.tested = LineBotApi('channel_secret')
         self.endpoint = LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/message/narrowcast'
         self.messages = [{
-            'type': 'text',
-            'text': 'Hello, world'
+            "type": "text",
+            "text": "Hello, world"
         }]
         self.recipient = None
         self.filter = None
@@ -53,23 +53,23 @@ class TestLineBotApi(unittest.TestCase):
     @responses.activate
     def test_narrowcast_text_message(self):
         self.recipient = {
-            'type': "audience",
-            'audienceGroupId': 5614991017776
+            "type": "audience",
+            "audienceGroupId": 5614991017776
         }
         self.filter = {
-            'demographic': {
-                'type': "area",
-                'oneOf': [
+            "demographic": {
+                "type": "area",
+                "oneOf": [
                     "android"
                 ]
             }
         }
-        self.limit = {'max': 100}
+        self.limit = {"max": 100}
         expected = {
-            'messages': self.messages,
-            'recipient': self.recipient,
-            'filter': self.filter,
-            'limit': self.limit,
+            "messages": self.messages,
+            "recipient": self.recipient,
+            "filter": self.filter,
+            "limit": self.limit,
         }
 
         responses.add(
@@ -89,7 +89,7 @@ class TestLineBotApi(unittest.TestCase):
 
         self.assertEqual(request.method, 'POST')
         self.assertEqual(request.url, self.endpoint)
-        self.assertEqual(request.body, json.dumps(expected))
+        self.assertEqual(json.loads(request.body), expected)
 
     @responses.activate
     def test_narrowcast_official_data(self):
@@ -175,10 +175,10 @@ class TestLineBotApi(unittest.TestCase):
             "max": 100
         }
         expected = {
-            'messages': self.messages,
-            'recipient': self.recipient,
-            'filter': self.filter,
-            'limit': self.limit
+            "messages": self.messages,
+            "recipient": self.recipient,
+            "filter": self.filter,
+            "limit": self.limit
         }
 
         responses.add(
@@ -197,7 +197,7 @@ class TestLineBotApi(unittest.TestCase):
 
         self.assertEqual(request.method, 'POST')
         self.assertEqual(request.url, self.endpoint)
-        self.assertEqual(request.body, json.dumps(expected))
+        self.assertEqual(json.loads(request.body), expected)
 
 
 if __name__ == '__main__':

--- a/tests/api/test_narrowcast.py
+++ b/tests/api/test_narrowcast.py
@@ -1,6 +1,22 @@
+# -*- coding: utf-8 -*-
+
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+from __future__ import unicode_literals, absolute_import
+
 import json
 import unittest
 import responses
+
 from linebot import LineBotApi
 
 


### PR DESCRIPTION
Issue: #236 
API spec: https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message 

### Programing problems:
`Operator` have `and`, `or` and  and` keyword,
but python can not use them to parameters,

### Here is my steps to fix `operator` issue:
- Use decorator to judge operator type.
- Narrowcast api use regex to replace UPPER operator case to lower.

Does any suggestion to improve operator Class model condition?
Thanks!