### PR TITLE
Add sender properties

### DIFF
--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -167,6 +167,7 @@ from .send_messages import (  # noqa
     StickerSendMessage,
     QuickReply,
     QuickReplyButton,
+    Sender,
 )
 from .sources import (  # noqa
     Source,

--- a/linebot/models/send_messages.py
+++ b/linebot/models/send_messages.py
@@ -32,6 +32,8 @@ class SendMessage(with_metaclass(ABCMeta, Base)):
 
         :param quick_reply: QuickReply object
         :type quick_reply: T <= :py:class:`linebot.models.send_messages.QuickReply`
+        :param sender: Sender object
+        :type sender: T <= :py:class:`linebot.models.send_messages.Sender`
         :param kwargs:
         """
         super(SendMessage, self).__init__(**kwargs)
@@ -236,9 +238,17 @@ class QuickReplyButton(with_metaclass(ABCMeta, Base)):
 
 
 class Sender(with_metaclass(ABCMeta, Base)):
+    """Sender.
+
+    https://developers.line.biz/en/reference/messaging-api/#icon-nickname-switch
+    """
 
     def __init__(self, name=None, icon_url=None, **kwargs):
+        """__init__ method.
 
+        :param str name: Display name
+        :param str icon_url: Icon image URL
+        """
         super(Sender, self).__init__(**kwargs)
 
         self.name = name

--- a/linebot/models/send_messages.py
+++ b/linebot/models/send_messages.py
@@ -27,7 +27,7 @@ from .base import Base
 class SendMessage(with_metaclass(ABCMeta, Base)):
     """Abstract Base Class of SendMessage."""
 
-    def __init__(self, quick_reply=None, **kwargs):
+    def __init__(self, quick_reply=None, sender=None, **kwargs):
         """__init__ method.
 
         :param quick_reply: QuickReply object
@@ -38,6 +38,7 @@ class SendMessage(with_metaclass(ABCMeta, Base)):
 
         self.type = None
         self.quick_reply = self.get_or_new_from_json_dict(quick_reply, QuickReply)
+        self.sender = self.get_or_new_from_json_dict(sender, Sender)
 
 
 class TextSendMessage(SendMessage):
@@ -232,3 +233,13 @@ class QuickReplyButton(with_metaclass(ABCMeta, Base)):
         self.type = 'action'
         self.image_url = image_url
         self.action = get_action(action)
+
+
+class Sender(with_metaclass(ABCMeta, Base)):
+
+    def __init__(self, name=None, icon_url=None, **kwargs):
+
+        super(Sender, self).__init__(**kwargs)
+
+        self.name = name
+        self.icon_url = icon_url

--- a/tests/api/test_send_text_message_with_sender.py
+++ b/tests/api/test_send_text_message_with_sender.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+from __future__ import unicode_literals, absolute_import
+
+import json
+import unittest
+
+import responses
+
+from linebot import (
+    LineBotApi
+)
+from linebot.models import (
+    TextSendMessage, Sender
+)
+
+
+class TestLineBotApi(unittest.TestCase):
+    def setUp(self):
+        self.tested = LineBotApi('channel_secret')
+
+        # test data
+        self.text_message = TextSendMessage(text='Hello, world')
+        self.message = [{"type": "text", "text": "Hello, world"}]
+
+    @responses.activate
+    def test_push_text_message_with_quick_reply(self):
+        responses.add(
+            responses.POST,
+            LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/message/push',
+            json={}, status=200
+        )
+
+        self.tested.push_message('to',
+                                 TextSendMessage(
+                                     text='Hello, world',
+                                     sender=Sender(
+                                         name='Cony',
+                                         icon_url='https://example.com/original.jpg'
+                                     )))
+
+        request = responses.calls[0].request
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(
+            request.url,
+            LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/message/push')
+        self.assertEqual(
+            json.loads(request.body),
+            {
+                "to": "to",
+                'notificationDisabled': False,
+                "messages": [
+                    {
+                        "type": "text",
+                        "text": "Hello, world",
+                        "sender": {
+                            "name": "Cony",
+                            "iconUrl": "https://example.com/original.jpg"
+                        }
+                    }
+                ]
+            }
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
closes https://github.com/line/line-bot-sdk-python/issues/248

- add sender properties.
- add test send message with sender

API Docs: https://developers.line.biz/en/reference/messaging-api/#icon-nickname-switch