### PR TITLE
fix deprecated url scheme in test code

### DIFF
--- a/tests/api/test_rich_menu.py
+++ b/tests/api/test_rich_menu.py
@@ -53,7 +53,7 @@ class TestLineBotApi(unittest.TestCase):
                         height=843
                     ),
                     URITemplateAction(
-                        uri='line://nv/location'
+                        uri='https://line.me/R/nv/location/'
                     )
                 )
             ]
@@ -139,7 +139,7 @@ class TestLineBotApi(unittest.TestCase):
                         height=843
                     ),
                     URITemplateAction(
-                        uri='line://nv/location'
+                        uri='https://line.me/R/nv/location/'
                     )
                 )
             ]


### PR DESCRIPTION
'line://' is deprecated.

https://developers.line.biz/en/news/2020/03/25/line-url-scheme-deprecation/
https://developers.line.biz/en/docs/line-login/using-line-url-scheme/#opening-the-location-screen