### PR TITLE
Support webhook setting APIs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -591,6 +591,46 @@ https://developers.line.biz/en/reference/messaging-api/#get-message-event
     insight = line_bot_api.get_insight_message_event(broadcast_response.request_id)
     print(insight.overview)
 
+set\_webhook\_endpoint(self, webhook_endpoint, timeout=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set the webhook endpoint URL.
+
+https://developers.line.biz/en/reference/messaging-api/#set-webhook-endpoint-url
+
+.. code:: python
+
+    line_bot_api.set_webhook_endpoint(<webhook_endpoint_URL>)
+
+get\_webhook\_endpoint(self, timeout=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Get information on a webhook endpoint.
+
+https://developers.line.biz/en/reference/messaging-api/#get-webhook-endpoint-information
+
+.. code:: python
+
+    webhook = line_bot_api.get_webhook_endpoint()
+    print(webhook.endpoint)
+    print(webhook.active)
+
+test\_webhook\_endpoint(self, webhook_endpoint=None, timeout=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Check if the configured webhook endpoint can receive a test webhook event.
+
+https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
+
+.. code:: python
+
+    test_result = line_bot_api.test_webhook_endpoint()
+    print(test_result.success)
+    print(test_result.timestamp)
+    print(test_result.status_code)
+    print(test_result.reason)
+    print(test_result.detail)
+
 ※ Error handling
 ^^^^^^^^^^^^^^^^^
 

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -1186,6 +1186,20 @@ class LineBotApi(object):
         self.__check_error(response)
         return response
 
+    def _put(self, path, endpoint=None, data=None, headers=None, timeout=None):
+        url = (endpoint or self.endpoint) + path
+
+        if headers is None:
+            headers = {'Content-Type': 'application/json'}
+        headers.update(self.headers)
+
+        response = self.http_client.put(
+            url, headers=headers, data=data, timeout=timeout
+        )
+
+        self.__check_error(response)
+        return response
+
     @staticmethod
     def __check_error(response):
         if 200 <= response.status_code < 300:

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -28,7 +28,7 @@ from .models import (
     MessageDeliveryPushResponse, MessageDeliveryReplyResponse,
     InsightMessageDeliveryResponse, InsightFollowersResponse, InsightDemographicResponse,
     InsightMessageEventResponse, BroadcastResponse, NarrowcastResponse,
-    MessageProgressNarrowcastResponse, GetWebhookResponse
+    MessageProgressNarrowcastResponse, GetWebhookResponse, TestWebhookResponse
 )
 from .models.responses import Group
 
@@ -1198,7 +1198,7 @@ class LineBotApi(object):
             timeout=timeout,
         )
 
-        return response.json
+        return TestWebhookResponse.new_from_json_dict(response.json)
 
     def _get(self, path, endpoint=None, params=None, headers=None, stream=False, timeout=None):
         url = (endpoint or self.endpoint) + path

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -1129,6 +1129,15 @@ class LineBotApi(object):
 
         return InsightMessageEventResponse.new_from_json_dict(response.json)
 
+    def set_webhook_endpoint(self, webhook_endpoint, timeout=None):
+        pass
+
+    def get_webhook_endpoint(self, timeout=None):
+        pass
+
+    def test_webhook_endpoint(self, webhook_endpoint=None, timeout=None):
+        pass
+
     def _get(self, path, endpoint=None, params=None, headers=None, stream=False, timeout=None):
         url = (endpoint or self.endpoint) + path
 

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -1130,7 +1130,16 @@ class LineBotApi(object):
         return InsightMessageEventResponse.new_from_json_dict(response.json)
 
     def set_webhook_endpoint(self, webhook_endpoint, timeout=None):
-        pass
+        
+        data={
+            'endpoint': webhook_endpoint
+        }
+
+        self._put(
+            '/v2/bot/channel/webhook/endpoint',
+            data=json.dumps(data),
+            timeout=timeout,
+        )
 
     def get_webhook_endpoint(self, timeout=None):
         

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -28,7 +28,7 @@ from .models import (
     MessageDeliveryPushResponse, MessageDeliveryReplyResponse,
     InsightMessageDeliveryResponse, InsightFollowersResponse, InsightDemographicResponse,
     InsightMessageEventResponse, BroadcastResponse, NarrowcastResponse,
-    MessageProgressNarrowcastResponse,
+    MessageProgressNarrowcastResponse, GetWebhookResponse
 )
 from .models.responses import Group
 
@@ -1170,7 +1170,7 @@ class LineBotApi(object):
             timeout=timeout,
         )
 
-        return response.json
+        return GetWebhookResponse.new_from_json_dict(response.json)
 
     def test_webhook_endpoint(self, webhook_endpoint=None, timeout=None):
         """Checks if the configured webhook endpoint can receive a test webhook event.

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -1165,7 +1165,7 @@ class LineBotApi(object):
             or a (connect timeout, read timeout) float tuple.
             Default is self.http_client.timeout
         :type timeout: float | tuple(float, float)
-        :rtype: dict
+        :rtype: :py:class:`linebot.models.responses.GetWebhookResponse`
         :return: Webhook information, including `endpoint` for webhook
             URL and `active` for webhook usage status.
         """
@@ -1189,7 +1189,7 @@ class LineBotApi(object):
             or a (connect timeout, read timeout) float tuple.
             Default is self.http_client.timeout
         :type timeout: float | tuple(float, float)
-        :rtype: dict
+        :rtype: :py:class:`linebot.models.responses.TestWebhookResponse`
         """
         data = {}
 

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -1130,8 +1130,8 @@ class LineBotApi(object):
         return InsightMessageEventResponse.new_from_json_dict(response.json)
 
     def set_webhook_endpoint(self, webhook_endpoint, timeout=None):
-        """Sets the webhook endpoint URL.
-        
+        """Set the webhook endpoint URL.
+
         https://developers.line.biz/en/reference/messaging-api/#set-webhook-endpoint-url
 
         :param str webhook_endpoint: A valid webhook URL to be set.
@@ -1141,7 +1141,7 @@ class LineBotApi(object):
             Default is self.http_client.timeout
         :type timeout: float | tuple(float, float)
         """
-        data={
+        data = {
             'endpoint': webhook_endpoint
         }
 
@@ -1152,8 +1152,8 @@ class LineBotApi(object):
         )
 
     def get_webhook_endpoint(self, timeout=None):
-        """Gets information on a webhook endpoint.
-        
+        """Get information on a webhook endpoint.
+
         https://developers.line.biz/en/reference/messaging-api/#get-webhook-endpoint-information
 
         :param timeout: (optional) How long to wait for the server
@@ -1174,9 +1174,9 @@ class LineBotApi(object):
 
     def test_webhook_endpoint(self, webhook_endpoint=None, timeout=None):
         """Checks if the configured webhook endpoint can receive a test webhook event.
-        
+
         https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
-        
+
         :param webhook_endpoint: (optional) Set this parameter to
             specific the webhook endpoint of the webhook. Default is the webhook
             endpoint that is already set to the channel.

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -1133,7 +1133,13 @@ class LineBotApi(object):
         pass
 
     def get_webhook_endpoint(self, timeout=None):
-        pass
+        
+        response = self._get(
+            '/v2/bot/channel/webhook/endpoint',
+            timeout=timeout,
+        )
+
+        return response.json
 
     def test_webhook_endpoint(self, webhook_endpoint=None, timeout=None):
         pass

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -1130,7 +1130,17 @@ class LineBotApi(object):
         return InsightMessageEventResponse.new_from_json_dict(response.json)
 
     def set_webhook_endpoint(self, webhook_endpoint, timeout=None):
+        """Sets the webhook endpoint URL.
         
+        https://developers.line.biz/en/reference/messaging-api/#set-webhook-endpoint-url
+
+        :param str webhook_endpoint: A valid webhook URL to be set.
+        :param timeout: (optional) How long to wait for the server
+            to send data before giving up, as a float,
+            or a (connect timeout, read timeout) float tuple.
+            Default is self.http_client.timeout
+        :type timeout: float | tuple(float, float)
+        """
         data={
             'endpoint': webhook_endpoint
         }
@@ -1142,7 +1152,19 @@ class LineBotApi(object):
         )
 
     def get_webhook_endpoint(self, timeout=None):
+        """Gets information on a webhook endpoint.
         
+        https://developers.line.biz/en/reference/messaging-api/#get-webhook-endpoint-information
+
+        :param timeout: (optional) How long to wait for the server
+            to send data before giving up, as a float,
+            or a (connect timeout, read timeout) float tuple.
+            Default is self.http_client.timeout
+        :type timeout: float | tuple(float, float)
+        :rtype: dict
+        :return: Webhook information, including `endpoint` for webhook
+            URL and `active` for webhook usage status.
+        """
         response = self._get(
             '/v2/bot/channel/webhook/endpoint',
             timeout=timeout,
@@ -1151,7 +1173,20 @@ class LineBotApi(object):
         return response.json
 
     def test_webhook_endpoint(self, webhook_endpoint=None, timeout=None):
+        """Checks if the configured webhook endpoint can receive a test webhook event.
         
+        https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
+        
+        :param webhook_endpoint: (optional) Set this parameter to
+            specific the webhook endpoint of the webhook. Default is the webhook
+            endpoint that is already set to the channel.
+        :param timeout: (optional) How long to wait for the server
+            to send data before giving up, as a float,
+            or a (connect timeout, read timeout) float tuple.
+            Default is self.http_client.timeout
+        :type timeout: float | tuple(float, float)
+        :rtype: dict
+        """
         data = {}
 
         if webhook_endpoint is not None:

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -1151,7 +1151,19 @@ class LineBotApi(object):
         return response.json
 
     def test_webhook_endpoint(self, webhook_endpoint=None, timeout=None):
-        pass
+        
+        data = {}
+
+        if webhook_endpoint is not None:
+            data['endpoint'] = webhook_endpoint
+
+        response = self._post(
+            '/v2/bot/channel/webhook/test',
+            data=json.dumps(data),
+            timeout=timeout,
+        )
+
+        return response.json
 
     def _get(self, path, endpoint=None, params=None, headers=None, stream=False, timeout=None):
         url = (endpoint or self.endpoint) + path

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -1140,16 +1140,20 @@ class LineBotApi(object):
             or a (connect timeout, read timeout) float tuple.
             Default is self.http_client.timeout
         :type timeout: float | tuple(float, float)
+        :rtype: dict
+        :return: Empty dict.
         """
         data = {
             'endpoint': webhook_endpoint
         }
 
-        self._put(
+        response = self._put(
             '/v2/bot/channel/webhook/endpoint',
             data=json.dumps(data),
             timeout=timeout,
         )
+
+        return response.json
 
     def get_webhook_endpoint(self, timeout=None):
         """Get information on a webhook endpoint.

--- a/linebot/http_client.py
+++ b/linebot/http_client.py
@@ -92,6 +92,9 @@ class HttpClient(with_metaclass(ABCMeta)):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def put(self, url, headers=None, data=None, timeout=None):
+        raise NotImplementedError
 
 class RequestsHttpClient(HttpClient):
     """HttpClient implemented by requests."""
@@ -177,6 +180,16 @@ class RequestsHttpClient(HttpClient):
 
         return RequestsHttpResponse(response)
 
+    def put(self, url, headers=None, data=None, timeout=None):
+        
+        if timeout is None:
+            timeout = self.timeout
+
+        response = requests.put(
+            url, headers=headers, data=data, timeout=timeout
+        )
+
+        return RequestsHttpResponse(response)
 
 class HttpResponse(with_metaclass(ABCMeta)):
     """HttpResponse."""

--- a/linebot/http_client.py
+++ b/linebot/http_client.py
@@ -94,7 +94,21 @@ class HttpClient(with_metaclass(ABCMeta)):
 
     @abstractmethod
     def put(self, url, headers=None, data=None, timeout=None):
+        """PUT request.
+
+        :param str url: Request url
+        :param dict headers: (optional) Request headers
+        :param data: (optional) Dictionary, bytes, or file-like object to send in the body
+        :param timeout: (optional), How long to wait for the server
+            to send data before giving up, as a float,
+            or a (connect timeout, read timeout) float tuple.
+            Default is :py:attr:`self.timeout`
+        :type timeout: float | tuple(float, float)
+        :rtype: :py:class:`RequestsHttpResponse`
+        :return: RequestsHttpResponse instance
+        """
         raise NotImplementedError
+
 
 class RequestsHttpClient(HttpClient):
     """HttpClient implemented by requests."""
@@ -181,7 +195,19 @@ class RequestsHttpClient(HttpClient):
         return RequestsHttpResponse(response)
 
     def put(self, url, headers=None, data=None, timeout=None):
-        
+        """PUT request.
+
+        :param str url: Request url
+        :param dict headers: (optional) Request headers
+        :param data: (optional) Dictionary, bytes, or file-like object to send in the body
+        :param timeout: (optional), How long to wait for the server
+            to send data before giving up, as a float,
+            or a (connect timeout, read timeout) float tuple.
+            Default is :py:attr:`self.timeout`
+        :type timeout: float | tuple(float, float)
+        :rtype: :py:class:`RequestsHttpResponse`
+        :return: RequestsHttpResponse instance
+        """
         if timeout is None:
             timeout = self.timeout
 
@@ -190,6 +216,7 @@ class RequestsHttpClient(HttpClient):
         )
 
         return RequestsHttpResponse(response)
+
 
 class HttpResponse(with_metaclass(ABCMeta)):
     """HttpResponse."""

--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -150,6 +150,7 @@ from .responses import (  # noqa
     BroadcastResponse,
     NarrowcastResponse,
     MessageProgressNarrowcastResponse,
+    GetWebhookResponse,
 )
 from .rich_menu import (  # noqa
     RichMenu,

--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -151,6 +151,7 @@ from .responses import (  # noqa
     NarrowcastResponse,
     MessageProgressNarrowcastResponse,
     GetWebhookResponse,
+    TestWebhookResponse,
 )
 from .rich_menu import (  # noqa
     RichMenu,

--- a/linebot/models/responses.py
+++ b/linebot/models/responses.py
@@ -516,3 +516,29 @@ class GetWebhookResponse(Base):
         self.endpoint = endpoint
         self.active = active
 
+
+class TestWebhookResponse(Base):
+    """Response of `test_webhook_endpoint()` .
+
+    https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
+    """
+
+    def __init__(self, success=None, timestamp=None, status_code=None,
+                 reason=None, detail=None, **kwargs):
+        """__init__ method.
+
+        :param bool success: Result of the communication from the LINE platform
+            to the webhook URL.
+        :param str timestamp: Timestamp
+        :param int status_code: The HTTP status code.
+        :param str reason: Reason for the response.
+        :param str detail: Details of the response.
+        :param kwargs:
+        """
+        super(TestWebhookResponse, self).__init__(**kwargs)
+
+        self.success = success
+        self.timestamp = timestamp
+        self.status_code = status_code
+        self.reason = reason
+        self.detail = detail

--- a/linebot/models/responses.py
+++ b/linebot/models/responses.py
@@ -496,3 +496,25 @@ class NarrowcastResponse(Base):
         super(NarrowcastResponse, self).__init__(**kwargs)
 
         self.request_id = request_id
+
+
+class GetWebhookResponse(Base):
+    """Response of `get_webhook_endpoint()` .
+
+    https://developers.line.biz/en/reference/messaging-api/#get-webhook-endpoint-information
+    """
+
+    def __init__(self, endpoint=None, active=None, **kwargs):
+        """__init__ method.
+
+        :param str endpoint: The webhook endpoint URL.
+        :param bool active: Whether the webhook is in use.
+        :param kwargs:
+        """
+        super(GetWebhookResponse, self).__init__(**kwargs)
+
+        self.endpoint = endpoint
+        if active == 'true':
+            self.active = True
+        elif active == 'false':
+            self.active = False

--- a/linebot/models/responses.py
+++ b/linebot/models/responses.py
@@ -514,7 +514,5 @@ class GetWebhookResponse(Base):
         super(GetWebhookResponse, self).__init__(**kwargs)
 
         self.endpoint = endpoint
-        if active == 'true':
-            self.active = True
-        elif active == 'false':
-            self.active = False
+        self.active = active
+

--- a/tests/api/test_get_webhook_endpoint.py
+++ b/tests/api/test_get_webhook_endpoint.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+from __future__ import unicode_literals, absolute_import
+
+import unittest
+
+import responses
+
+from linebot import (
+    LineBotApi
+)
+
+
+class TestLineBotApi(unittest.TestCase):
+    def setUp(self):
+        self.tested = LineBotApi('channel_secret')
+
+    @responses.activate
+    def test_get_webhook_endpoint(self):
+        responses.add(
+            responses.GET,
+            LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/endpoint',
+            json={
+                "endpoint": "https://example.herokuapp.com/test",
+                "active": "true",
+            },
+            status=200
+        )
+
+        webhook = self.tested.get_webhook_endpoint()
+
+        request = responses.calls[0].request
+        self.assertEqual(request.method, 'GET')
+        self.assertEqual(
+            request.url,
+            LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/endpoint')
+        self.assertEqual(webhook['endpoint'], 'https://example.herokuapp.com/test')
+        self.assertEqual(webhook['active'], 'true')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/api/test_get_webhook_endpoint.py
+++ b/tests/api/test_get_webhook_endpoint.py
@@ -34,7 +34,7 @@ class TestLineBotApi(unittest.TestCase):
             LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/endpoint',
             json={
                 "endpoint": "https://example.herokuapp.com/test",
-                "active": "true",
+                "active": True,
             },
             status=200
         )

--- a/tests/api/test_get_webhook_endpoint.py
+++ b/tests/api/test_get_webhook_endpoint.py
@@ -46,8 +46,8 @@ class TestLineBotApi(unittest.TestCase):
         self.assertEqual(
             request.url,
             LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/endpoint')
-        self.assertEqual(webhook['endpoint'], 'https://example.herokuapp.com/test')
-        self.assertEqual(webhook['active'], 'true')
+        self.assertEqual(webhook.endpoint, 'https://example.herokuapp.com/test')
+        self.assertEqual(webhook.active, True)
 
 
 if __name__ == '__main__':

--- a/tests/api/test_set_webhook_endpoint.py
+++ b/tests/api/test_set_webhook_endpoint.py
@@ -36,13 +36,14 @@ class TestLineBotApi(unittest.TestCase):
             status=200
         )
 
-        self.tested.set_webhook_endpoint('endpoint')
+        result = self.tested.set_webhook_endpoint('endpoint')
 
         request = responses.calls[0].request
         self.assertEqual(request.method, 'PUT')
         self.assertEqual(
             request.url,
             LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/endpoint')
+        self.assertEqual(result, {})
 
 
 if __name__ == '__main__':

--- a/tests/api/test_set_webhook_endpoint.py
+++ b/tests/api/test_set_webhook_endpoint.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+from __future__ import unicode_literals, absolute_import
+
+import unittest
+
+import responses
+
+from linebot import (
+    LineBotApi
+)
+
+
+class TestLineBotApi(unittest.TestCase):
+    def setUp(self):
+        self.tested = LineBotApi('channel_secret')
+
+    @responses.activate
+    def test_set_webhook_endpoint(self):
+        responses.add(
+            responses.PUT,
+            LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/endpoint',
+            json={},
+            status=200
+        )
+
+        result = self.tested.set_webhook_endpoint('endpoint')
+
+        request = responses.calls[0].request
+        self.assertEqual(request.method, 'PUT')
+        self.assertEqual(
+            request.url,
+            LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/endpoint')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/api/test_set_webhook_endpoint.py
+++ b/tests/api/test_set_webhook_endpoint.py
@@ -36,7 +36,7 @@ class TestLineBotApi(unittest.TestCase):
             status=200
         )
 
-        result = self.tested.set_webhook_endpoint('endpoint')
+        self.tested.set_webhook_endpoint('endpoint')
 
         request = responses.calls[0].request
         self.assertEqual(request.method, 'PUT')

--- a/tests/api/test_test_webhook_endpoint.py
+++ b/tests/api/test_test_webhook_endpoint.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+from __future__ import unicode_literals, absolute_import
+
+import unittest
+
+import responses
+
+from linebot import (
+    LineBotApi
+)
+
+
+class TestLineBotApi(unittest.TestCase):
+    def setUp(self):
+        self.tested = LineBotApi('channel_secret')
+
+    @responses.activate
+    def test_test_webhook_endpoint_with_endpoint(self):
+        responses.add(
+            responses.POST,
+            LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/test',
+            json={
+                "success": "true",
+                "timestamp": "2020-09-30T05:38:20.031Z",
+                "statusCode": 200,
+                "reason": "OK",
+                "detail": "200"
+            },
+            status=200
+        )
+
+        result = self.tested.test_webhook_endpoint('endpoint')
+
+        request = responses.calls[0].request
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(
+            request.url,
+            LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/test')
+        self.assertEqual(result['success'], 'true')
+        self.assertEqual(result['timestamp'], '2020-09-30T05:38:20.031Z')
+        self.assertEqual(result['statusCode'], 200)
+        self.assertEqual(result['reason'], 'OK')
+        self.assertEqual(result['detail'], '200')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/api/test_test_webhook_endpoint.py
+++ b/tests/api/test_test_webhook_endpoint.py
@@ -33,7 +33,7 @@ class TestLineBotApi(unittest.TestCase):
             responses.POST,
             LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/test',
             json={
-                "success": "true",
+                "success": True,
                 "timestamp": "2020-09-30T05:38:20.031Z",
                 "statusCode": 200,
                 "reason": "OK",
@@ -49,11 +49,11 @@ class TestLineBotApi(unittest.TestCase):
         self.assertEqual(
             request.url,
             LineBotApi.DEFAULT_API_ENDPOINT + '/v2/bot/channel/webhook/test')
-        self.assertEqual(result['success'], 'true')
-        self.assertEqual(result['timestamp'], '2020-09-30T05:38:20.031Z')
-        self.assertEqual(result['statusCode'], 200)
-        self.assertEqual(result['reason'], 'OK')
-        self.assertEqual(result['detail'], '200')
+        self.assertEqual(result.success, True)
+        self.assertEqual(result.timestamp, '2020-09-30T05:38:20.031Z')
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.reason, 'OK')
+        self.assertEqual(result.detail, '200')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Dear Maintainers,

This PR implemented the following three APIs of webhook settings, which were also mentioned in #298 .

- Get webhook endpoint information
- Set webhook endpoint URL
- Test webhook endpoint

This is my first PR on this repository, tell me if I miss something. Also, if you please, label this PR as `hacktoberfest-accepted` .