### PR TITLE
Remove unnecessary (utf-8) decode

### DIFF
--- a/examples/managing-audiences/test_audienceGroup.py
+++ b/examples/managing-audiences/test_audienceGroup.py
@@ -52,7 +52,7 @@ class LineBotApi(LineBotApi_ori):
         audience_groups = super(LineBotApi, self).get_audience_group_list(
             description=description, timeout=timeout)
         for audience_group in audience_groups:
-            if audience_group.description.encode('utf-8') == description:
+            if audience_group.description == description:
                 return audience_group.audience_group_id
         else:
             return None


### PR DESCRIPTION
```
def get_audience_gid_by_name(self, description, timeout=None):
        audience_groups = super(LineBotApiC, self).get_audience_group_list(
            description=description, timeout=timeout)
        for audience_group in audience_groups:
            if audience_group.description == description:
                return audience_group.audience_group_id
        else:
            return None
```

It seems that only by removing `.encode('utf-8')` we are able to get audience_group_id properly. 