### PR TITLE
require RichMenuSwitchAction in linebot/models

### DIFF
--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -23,6 +23,7 @@ from .actions import (  # noqa
     CameraAction,
     CameraRollAction,
     LocationAction,
+    RichMenuSwitchAction,
     Action as TemplateAction,  # backward compatibility
     PostbackAction as PostbackTemplateAction,  # backward compatibility
     MessageAction as MessageTemplateAction,  # backward compatibility


### PR DESCRIPTION
I cannnot require RichMenuSwitchAction from linebot/models :(

```
Traceback (most recent call last):
  File "xxx/main.py", line 5, in <module>
    from linebot.models import (
ImportError: cannot import name 'RichMenuSwitchAction' from 'linebot.models' (xxx/.local/share/virtualenvs/python--g_QApAx/lib/python3.9/site-packages/linebot/models/__init__.py)
```
