### PR TITLE
add module name RichMenuAlias to rich_menu import

### DIFF
--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -167,6 +167,7 @@ from .rich_menu import (  # noqa
     RichMenuSize,
     RichMenuArea,
     RichMenuBounds,
+    RichMenuAlias,
 )
 from .send_messages import (  # noqa
     SendMessage,


### PR DESCRIPTION
This is a pull request related to issue number #347