### PR TITLE
Add an argument missing arugment of ImageComponent

### DIFF
--- a/linebot/models/flex_message.py
+++ b/linebot/models/flex_message.py
@@ -501,6 +501,7 @@ class ImageComponent(FlexComponent):
                  aspect_mode=None,
                  background_color=None,
                  action=None,
+                 animated=None,
                  **kwargs):
         """__init__ method.
 
@@ -523,6 +524,7 @@ class ImageComponent(FlexComponent):
         :param str background_color: Background color of the image. Use a hexadecimal color code.
         :param action: Action performed when this image is tapped
         :type action: list[T <= :py:class:`linebot.models.actions.Action`]
+        :param bool action: True to play an animated image
         :param kwargs:
         """
         super(ImageComponent, self).__init__(**kwargs)
@@ -542,6 +544,7 @@ class ImageComponent(FlexComponent):
         self.aspect_mode = aspect_mode
         self.background_color = background_color
         self.action = get_action(action)
+        self.animated = animated
 
 
 class SeparatorComponent(FlexComponent):


### PR DESCRIPTION
The image component of the flex message has an argument `animated`, but it was missing. Perhaps this resolve #383 