### PR TITLE
Add Unknown event

### DIFF
--- a/examples/flask-kitchensink/app.py
+++ b/examples/flask-kitchensink/app.py
@@ -41,7 +41,7 @@ from linebot.models import (
     StickerMessage, StickerSendMessage, LocationMessage, LocationSendMessage,
     ImageMessage, VideoMessage, AudioMessage, FileMessage,
     UnfollowEvent, FollowEvent, JoinEvent, LeaveEvent, BeaconEvent,
-    MemberJoinedEvent, MemberLeftEvent,
+    MemberJoinedEvent, MemberLeftEvent, UnknownEvent,
     FlexSendMessage, BubbleContainer, ImageComponent, BoxComponent,
     TextComponent, IconComponent, ButtonComponent,
     SeparatorComponent, QuickReply, QuickReplyButton,
@@ -678,6 +678,11 @@ def handle_member_joined(event):
 @handler.add(MemberLeftEvent)
 def handle_member_left(event):
     app.logger.info("Got memberLeft event")
+
+
+@handler.add(UnknownEvent)
+def handle_unknown_left(event):
+    app.logger.info(f"unknown event {event}")
 
 
 @app.route('/static/<path:path>')

--- a/linebot/models/__init__.py
+++ b/linebot/models/__init__.py
@@ -51,6 +51,7 @@ from .events import (  # noqa
     MemberLeftEvent,
     BeaconEvent,
     ThingsEvent,
+    UnknownEvent,
     Postback,
     Beacon,
     Link,

--- a/linebot/models/events.py
+++ b/linebot/models/events.py
@@ -498,6 +498,7 @@ class UnknownEvent(Event):
 
     def __init__(self, **kwargs):
         """__init__ method.
+
         :param kwargs:
         """
         super(UnknownEvent, self).__init__(**kwargs)

--- a/linebot/models/events.py
+++ b/linebot/models/events.py
@@ -490,6 +490,21 @@ class VideoPlayCompleteEvent(Event):
         )
 
 
+class UnknownEvent(Event):
+    """Unknown event.
+
+    We welcome your contribution to line-bot-sdk-python!
+    """
+
+    def __init__(self, **kwargs):
+        """__init__ method.
+        :param kwargs:
+        """
+        super(UnknownEvent, self).__init__(**kwargs)
+
+        self.type = 'unknown'
+
+
 class Postback(Base):
     """Postback.
 

--- a/linebot/webhook.py
+++ b/linebot/webhook.py
@@ -33,7 +33,10 @@ from .models.events import (
     AccountLinkEvent,
     MemberJoinedEvent,
     MemberLeftEvent,
-    ThingsEvent, UnsendEvent, VideoPlayCompleteEvent,
+    ThingsEvent,
+    UnsendEvent,
+    VideoPlayCompleteEvent,
+    UnknownEvent,
 )
 from .utils import LOGGER, PY3, safe_compare_digest
 
@@ -172,7 +175,8 @@ class WebhookParser(object):
             elif event_type == 'videoPlayComplete':
                 events.append(VideoPlayCompleteEvent.new_from_json_dict(event))
             else:
-                LOGGER.warn('Unknown event type. type=' + event_type)
+                LOGGER.info('Unknown event type. type=' + event_type)
+                events.append(UnknownEvent.new_from_json_dict(event))
 
         if as_payload:
             return WebhookPayload(events=events, destination=body_json.get('destination'))

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -26,6 +26,7 @@ from linebot.models import (
     MessageEvent, FollowEvent, UnfollowEvent, JoinEvent,
     LeaveEvent, PostbackEvent, BeaconEvent, AccountLinkEvent,
     MemberJoinedEvent, MemberLeftEvent, ThingsEvent,
+    UnknownEvent,
     TextMessage, ImageMessage, VideoMessage, AudioMessage,
     LocationMessage, StickerMessage, FileMessage,
     SourceUser, SourceRoom, SourceGroup,
@@ -69,7 +70,7 @@ class TestWebhookParser(unittest.TestCase):
         events = self.parser.parse(body, 'channel_secret')
 
         # events count
-        self.assertEqual(len(events), 29)
+        self.assertEqual(len(events), 30)
 
         # MessageEvent, SourceUser, TextMessage
         self.assertIsInstance(events[0], MessageEvent)
@@ -566,6 +567,9 @@ class TestWebhookParser(unittest.TestCase):
         self.assertEqual(events[28].message.id, '325708')
         self.assertEqual(events[28].message.type, 'text')
         self.assertEqual(events[28].message.text, 'Hello, world')
+
+        # UnknownEvent
+        self.assertIsInstance(events[29], UnknownEvent)
 
     def test_parse_webhook_req_without_destination(self):
         body = """

--- a/tests/text/webhook.json
+++ b/tests/text/webhook.json
@@ -581,6 +581,22 @@
         "type": "text",
         "text": "Hello, world"
       }
+    },
+    {
+      "type": "undefined",
+      "mode": "active",
+      "timestamp": 1462629479859,
+      "source": {
+        "type": "user",
+        "userId": "U206d25c2ea6bd87c17655609a1c37cb8"
+      },
+      "webhookEventId": "testwebhookeventid",
+      "deliveryContext": {
+        "isRedelivery": true
+      },
+      "undefinedField": {
+        "1": 1
+      }
     }
   ]
 }


### PR DESCRIPTION
Most line-bot SDKs allow developers to receive undefined events in their own applications. However, this project only logs a warning message developers can't control, and application can't receive events if it uses [`WebhookHandler`](https://github.com/line/line-bot-sdk-python/blob/524fd94c48b9c79c89db2c7aa3792be25ead2ab4/linebot/webhook.py#L183). This pull request suppresses the warn log, and newly defines unknown events so that application can receive them and response to LINE users.