### PR TITLE
Modify README.rst to pass validation

### DIFF
--- a/.github/workflows/auto-testing.yml
+++ b/.github/workflows/auto-testing.yml
@@ -27,3 +27,7 @@ jobs:
     - name: Test with pytest
       run: |
         tox
+    - name: Ensure README.rst builds correctly for PyPI
+      run: |
+        pip install readme-renderer
+        python -m readme_renderer README.rst >/dev/null

--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ Examples
 Sample echo-bot with asynchronous processings.
 
 `fastapi-echo <examples/fastapi-echo>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sample echo-bot using `FastAPI <https://fastapi.tiangolo.com/>`__
 
@@ -321,6 +321,13 @@ You can generate new or fixed models and APIs by this command.
 
 
 When you update line-bot-sdk-python version, please update `linebot/__about__.py <linebot/__about__.py>`__ and generate code again.
+
+
+If you edit `README.rst <README.rst>`__, you should execute the following command to check the syntax of README.
+
+::
+
+    $ python -m readme_renderer README.rst
 
 
 Run tests


### PR DESCRIPTION
It failed on releasing `3.0.0` (https://github.com/line/line-bot-sdk-python/actions/runs/5408969110).
This pull request fixes it and adds tests to prevent such a fix from happening again.