### PR TITLE
Replace old liff functions with new ones and keep backward compatibility

### DIFF
--- a/generate-code.py
+++ b/generate-code.py
@@ -5,6 +5,17 @@ def run_command(command):
     output = subprocess.check_output(command, shell=True)
     return output.decode('utf-8').strip()
 
+import fileinput
+
+def replace_text_in_files(dir_path: str, text_to_search: str, text_to_replace: str):
+    for foldername, subfolders, filenames in os.walk(dir_path):
+        for filename in filenames:
+            file_path = os.path.join(foldername, filename)
+            with fileinput.FileInput(file_path, inplace=True) as file:
+                for line in file:
+                    print(line.replace(text_to_search, text_to_replace), end='')
+
+
 def main():
 
     os.chdir("generator")
@@ -67,6 +78,56 @@ def main():
                 -i line-openapi/{sourceYaml}
               '''
     run_command(command)
+
+    ##
+    ## TODO(v4): Delete this workaround in v4 and use operation-id in line-openapi.
+    ## This workaround is to avoid breaking change in v3.
+
+    ## POST   /liff/v1/apps          <- addLIFFApp
+    ## GET    /liff/v1/apps          <- getAllLIFFApps
+    ## PUT    /liff/v1/apps/{liffId} <- updateLIFFApp
+    ## DELETE /liff/v1/apps/{liffId} <- deleteLIFFApp
+
+    replace_text_in_files('./linebot/v3/liff/api', 'get_all_liff_apps(', 'liff_v1_apps_get(')
+    replace_text_in_files('./linebot/v3/liff/api', 'get_all_liff_apps  ', 'liff_v1_apps_get  ')
+    replace_text_in_files('./linebot/v3/liff/api', 'method get_all_liff_apps', 'method liff_v1_apps_get')
+    replace_text_in_files('./linebot/v3/liff/api', 'get_all_liff_apps_with_http_info(', 'liff_v1_apps_get_with_http_info(')
+    replace_text_in_files('./linebot/v3/liff/api', 'get_all_liff_apps_with_http_info method', 'liff_v1_apps_get_with_http_info method')
+    replace_text_in_files('./linebot/v3/liff/docs', 'get_all_liff_apps(', 'liff_v1_apps_get(')
+    replace_text_in_files('./linebot/v3/liff/docs', 'get_all_liff_apps**', 'liff_v1_apps_get**')
+    replace_text_in_files('./linebot/v3/liff/docs', 'get_all_liff_apps:', 'liff_v1_apps_get:')
+    replace_text_in_files('./linebot/v3/liff/docs', 'get_all_liff_apps)', 'liff_v1_apps_get)')
+
+    replace_text_in_files('./linebot/v3/liff/api', 'add_liff_app(', 'liff_v1_apps_post(')
+    replace_text_in_files('./linebot/v3/liff/api', 'add_liff_app  ', 'liff_v1_apps_post  ')
+    replace_text_in_files('./linebot/v3/liff/api', 'method add_liff_app', 'method liff_v1_apps_post')
+    replace_text_in_files('./linebot/v3/liff/api', 'add_liff_app_with_http_info(', 'liff_v1_apps_post_with_http_info(')
+    replace_text_in_files('./linebot/v3/liff/api', 'add_liff_app_with_http_info method', 'liff_v1_apps_post_with_http_info method')
+    replace_text_in_files('./linebot/v3/liff/docs', 'add_liff_app(', 'liff_v1_apps_post(')
+    replace_text_in_files('./linebot/v3/liff/docs', 'add_liff_app**', 'liff_v1_apps_post**')
+    replace_text_in_files('./linebot/v3/liff/docs', 'add_liff_app:', 'liff_v1_apps_post:')
+    replace_text_in_files('./linebot/v3/liff/docs', 'add_liff_app)', 'liff_v1_apps_post)')
+
+    replace_text_in_files('./linebot/v3/liff/api', 'update_liff_app(', 'liff_v1_apps_liff_id_put(')
+    replace_text_in_files('./linebot/v3/liff/api', 'update_liff_app  ', 'liff_v1_apps_liff_id_put  ')
+    replace_text_in_files('./linebot/v3/liff/api', 'method update_liff_app', 'method liff_v1_apps_liff_id_put')
+    replace_text_in_files('./linebot/v3/liff/api', 'update_liff_app_with_http_info(', 'liff_v1_apps_liff_id_put_with_http_info(')
+    replace_text_in_files('./linebot/v3/liff/api', 'update_liff_app_with_http_info method', 'liff_v1_apps_liff_id_put_with_http_info method')
+    replace_text_in_files('./linebot/v3/liff/docs', 'update_liff_app(', 'liff_v1_apps_liff_id_put(')
+    replace_text_in_files('./linebot/v3/liff/docs', 'update_liff_app**', 'liff_v1_apps_liff_id_put**')
+    replace_text_in_files('./linebot/v3/liff/docs', 'update_liff_app:', 'liff_v1_apps_liff_id_put:')
+    replace_text_in_files('./linebot/v3/liff/docs', 'update_liff_app)', 'liff_v1_apps_liff_id_put)')
+
+    replace_text_in_files('./linebot/v3/liff/api', 'delete_liff_app(', 'liff_v1_apps_liff_id_delete(')
+    replace_text_in_files('./linebot/v3/liff/api', 'delete_liff_app  ', 'liff_v1_apps_liff_id_delete  ')
+    replace_text_in_files('./linebot/v3/liff/api', 'method delete_liff_app', 'method liff_v1_apps_liff_id_delete')
+    replace_text_in_files('./linebot/v3/liff/api', 'delete_liff_app_with_http_info(', 'liff_v1_apps_liff_id_delete_with_http_info(')
+    replace_text_in_files('./linebot/v3/liff/api', 'delete_liff_app_with_http_info method', 'liff_v1_apps_liff_id_delete_with_http_info method')
+    replace_text_in_files('./linebot/v3/liff/docs', 'delete_liff_app(', 'liff_v1_apps_liff_id_delete(')
+    replace_text_in_files('./linebot/v3/liff/docs', 'delete_liff_app**', 'liff_v1_apps_liff_id_delete**')
+    replace_text_in_files('./linebot/v3/liff/docs', 'delete_liff_app:', 'liff_v1_apps_liff_id_delete:')
+    replace_text_in_files('./linebot/v3/liff/docs', 'delete_liff_app)', 'liff_v1_apps_liff_id_delete)')
+
 
 if __name__ == "__main__":
     main()

--- a/generate-code.py
+++ b/generate-code.py
@@ -1,19 +1,37 @@
 import os
 import subprocess
+import fnmatch
+from typing import List, Tuple
 
 def run_command(command):
     output = subprocess.check_output(command, shell=True)
     return output.decode('utf-8').strip()
 
-import fileinput
+def replace_in_file(file_path: str, replacements: List[Tuple[str, str]]):
+    with open(file_path, 'r') as file:
+        filedata = file.read()
+    for k, v in replacements:
+        filedata = filedata.replace(k, v)
+    with open(file_path, 'w') as file:
+        file.write(filedata)
 
-def replace_text_in_files(dir_path: str, text_to_search: str, text_to_replace: str):
-    for foldername, subfolders, filenames in os.walk(dir_path):
-        for filename in filenames:
-            file_path = os.path.join(foldername, filename)
-            with fileinput.FileInput(file_path, inplace=True) as file:
-                for line in file:
-                    print(line.replace(text_to_search, text_to_replace), end='')
+def replace_in_files(directory: str, replacements: List[Tuple[str, str]]):
+    for path, dirs, files in os.walk(directory):
+        for filename in fnmatch.filter(files, "*"):
+            file_path = os.path.join(path, filename)
+            replace_in_file(file_path, replacements)
+
+def replace_in_files_by_keyword(directory: str, wrong_function_name: str, original_function_name: str, prefix: List[str], suffix: List[str]):
+    replacements = []
+    for x in prefix:
+        replacements.append((x + wrong_function_name, x + original_function_name))
+    for x in suffix:
+        replacements.append((wrong_function_name + x, original_function_name + x))
+    replace_in_files(directory, replacements)
+
+def replace_liff_function_name(wrong_function_name: str, original_function_name: str):
+    replace_in_files_by_keyword('./linebot/v3/liff/api', wrong_function_name, original_function_name, ['method '], ['(', '  ', '_with_http_info(', '_with_http_info method'])
+    replace_in_files_by_keyword('./linebot/v3/liff/docs', wrong_function_name, original_function_name, [], ['(', '**', ':', ')'])
 
 
 def main():
@@ -79,54 +97,18 @@ def main():
               '''
     run_command(command)
 
-    ##
+
     ## TODO(v4): Delete this workaround in v4 and use operation-id in line-openapi.
     ## This workaround is to avoid breaking change in v3.
 
-    ## POST   /liff/v1/apps          <- addLIFFApp
     ## GET    /liff/v1/apps          <- getAllLIFFApps
+    replace_liff_function_name('get_all_liff_apps', 'liff_v1_apps_get')
+    ## POST   /liff/v1/apps          <- addLIFFApp
+    replace_liff_function_name('add_liff_app', 'liff_v1_apps_post')
     ## PUT    /liff/v1/apps/{liffId} <- updateLIFFApp
+    replace_liff_function_name('update_liff_app', 'liff_v1_apps_liff_id_put')
     ## DELETE /liff/v1/apps/{liffId} <- deleteLIFFApp
-
-    replace_text_in_files('./linebot/v3/liff/api', 'get_all_liff_apps(', 'liff_v1_apps_get(')
-    replace_text_in_files('./linebot/v3/liff/api', 'get_all_liff_apps  ', 'liff_v1_apps_get  ')
-    replace_text_in_files('./linebot/v3/liff/api', 'method get_all_liff_apps', 'method liff_v1_apps_get')
-    replace_text_in_files('./linebot/v3/liff/api', 'get_all_liff_apps_with_http_info(', 'liff_v1_apps_get_with_http_info(')
-    replace_text_in_files('./linebot/v3/liff/api', 'get_all_liff_apps_with_http_info method', 'liff_v1_apps_get_with_http_info method')
-    replace_text_in_files('./linebot/v3/liff/docs', 'get_all_liff_apps(', 'liff_v1_apps_get(')
-    replace_text_in_files('./linebot/v3/liff/docs', 'get_all_liff_apps**', 'liff_v1_apps_get**')
-    replace_text_in_files('./linebot/v3/liff/docs', 'get_all_liff_apps:', 'liff_v1_apps_get:')
-    replace_text_in_files('./linebot/v3/liff/docs', 'get_all_liff_apps)', 'liff_v1_apps_get)')
-
-    replace_text_in_files('./linebot/v3/liff/api', 'add_liff_app(', 'liff_v1_apps_post(')
-    replace_text_in_files('./linebot/v3/liff/api', 'add_liff_app  ', 'liff_v1_apps_post  ')
-    replace_text_in_files('./linebot/v3/liff/api', 'method add_liff_app', 'method liff_v1_apps_post')
-    replace_text_in_files('./linebot/v3/liff/api', 'add_liff_app_with_http_info(', 'liff_v1_apps_post_with_http_info(')
-    replace_text_in_files('./linebot/v3/liff/api', 'add_liff_app_with_http_info method', 'liff_v1_apps_post_with_http_info method')
-    replace_text_in_files('./linebot/v3/liff/docs', 'add_liff_app(', 'liff_v1_apps_post(')
-    replace_text_in_files('./linebot/v3/liff/docs', 'add_liff_app**', 'liff_v1_apps_post**')
-    replace_text_in_files('./linebot/v3/liff/docs', 'add_liff_app:', 'liff_v1_apps_post:')
-    replace_text_in_files('./linebot/v3/liff/docs', 'add_liff_app)', 'liff_v1_apps_post)')
-
-    replace_text_in_files('./linebot/v3/liff/api', 'update_liff_app(', 'liff_v1_apps_liff_id_put(')
-    replace_text_in_files('./linebot/v3/liff/api', 'update_liff_app  ', 'liff_v1_apps_liff_id_put  ')
-    replace_text_in_files('./linebot/v3/liff/api', 'method update_liff_app', 'method liff_v1_apps_liff_id_put')
-    replace_text_in_files('./linebot/v3/liff/api', 'update_liff_app_with_http_info(', 'liff_v1_apps_liff_id_put_with_http_info(')
-    replace_text_in_files('./linebot/v3/liff/api', 'update_liff_app_with_http_info method', 'liff_v1_apps_liff_id_put_with_http_info method')
-    replace_text_in_files('./linebot/v3/liff/docs', 'update_liff_app(', 'liff_v1_apps_liff_id_put(')
-    replace_text_in_files('./linebot/v3/liff/docs', 'update_liff_app**', 'liff_v1_apps_liff_id_put**')
-    replace_text_in_files('./linebot/v3/liff/docs', 'update_liff_app:', 'liff_v1_apps_liff_id_put:')
-    replace_text_in_files('./linebot/v3/liff/docs', 'update_liff_app)', 'liff_v1_apps_liff_id_put)')
-
-    replace_text_in_files('./linebot/v3/liff/api', 'delete_liff_app(', 'liff_v1_apps_liff_id_delete(')
-    replace_text_in_files('./linebot/v3/liff/api', 'delete_liff_app  ', 'liff_v1_apps_liff_id_delete  ')
-    replace_text_in_files('./linebot/v3/liff/api', 'method delete_liff_app', 'method liff_v1_apps_liff_id_delete')
-    replace_text_in_files('./linebot/v3/liff/api', 'delete_liff_app_with_http_info(', 'liff_v1_apps_liff_id_delete_with_http_info(')
-    replace_text_in_files('./linebot/v3/liff/api', 'delete_liff_app_with_http_info method', 'liff_v1_apps_liff_id_delete_with_http_info method')
-    replace_text_in_files('./linebot/v3/liff/docs', 'delete_liff_app(', 'liff_v1_apps_liff_id_delete(')
-    replace_text_in_files('./linebot/v3/liff/docs', 'delete_liff_app**', 'liff_v1_apps_liff_id_delete**')
-    replace_text_in_files('./linebot/v3/liff/docs', 'delete_liff_app:', 'liff_v1_apps_liff_id_delete:')
-    replace_text_in_files('./linebot/v3/liff/docs', 'delete_liff_app)', 'liff_v1_apps_liff_id_delete)')
+    replace_liff_function_name('delete_liff_app', 'liff_v1_apps_liff_id_delete')
 
 
 if __name__ == "__main__":

--- a/generate-code.py
+++ b/generate-code.py
@@ -1,38 +1,28 @@
 import os
 import subprocess
-import fnmatch
-from typing import List, Tuple
 
 def run_command(command):
     output = subprocess.check_output(command, shell=True)
     return output.decode('utf-8').strip()
 
-def replace_in_file(file_path: str, replacements: List[Tuple[str, str]]):
-    with open(file_path, 'r') as file:
-        filedata = file.read()
-    for k, v in replacements:
-        filedata = filedata.replace(k, v)
-    with open(file_path, 'w') as file:
-        file.write(filedata)
 
-def replace_in_files(directory: str, replacements: List[Tuple[str, str]]):
-    for path, dirs, files in os.walk(directory):
-        for filename in fnmatch.filter(files, "*"):
-            file_path = os.path.join(path, filename)
-            replace_in_file(file_path, replacements)
-
-def replace_in_files_by_keyword(directory: str, wrong_function_name: str, original_function_name: str, prefix: List[str], suffix: List[str]):
-    replacements = []
-    for x in prefix:
-        replacements.append((x + wrong_function_name, x + original_function_name))
-    for x in suffix:
-        replacements.append((wrong_function_name + x, original_function_name + x))
-    replace_in_files(directory, replacements)
-
-def replace_liff_function_name(wrong_function_name: str, original_function_name: str):
-    replace_in_files_by_keyword('./linebot/v3/liff/api', wrong_function_name, original_function_name, ['method '], ['(', '  ', '_with_http_info(', '_with_http_info method'])
-    replace_in_files_by_keyword('./linebot/v3/liff/docs', wrong_function_name, original_function_name, [], ['(', '**', ':', ')'])
-
+def rewrite_liff_function_name_backward_compats():
+    for fname in ['liff.py', 'async_liff.py']:
+        with open(f'linebot/v3/liff/api/{fname}', 'a') as fp:
+             fp.write("\n\n")
+             for (orig, cur) in [('liff_v1_apps_get', 'get_all_liff_apps'),
+                                 ('liff_v1_apps_get_with_http_info', 'get_all_liff_apps_with_http_info'),
+                                 ('liff_v1_apps_post', 'add_liff_app'),
+                                 ('liff_v1_apps_post_with_http_info', 'add_liff_app_with_http_info'),
+                                 ('liff_v1_apps_liff_id_put', 'update_liff_app'),
+                                 ('liff_v1_apps_liff_id_put_with_http_info', 'update_liff_app_with_http_info'),
+                                 ('liff_v1_apps_liff_id_delete', 'delete_liff_app'),
+                                 ('liff_v1_apps_liff_id_delete_with_http_info', 'delete_liff_app_with_http_info')]:
+                 fp.write(f"\n")
+                 fp.write(f"    def {orig}(self, *args, **kwargs):\n")
+                 fp.write(f"        import warnings\n")
+                 fp.write(f"        warnings.warn('{orig} was deprecated. use {cur} instead.', DeprecationWarning)\n")
+                 fp.write(f"        return self.{cur}(*args, **kwargs)\n")
 
 def main():
 
@@ -100,15 +90,7 @@ def main():
 
     ## TODO(v4): Delete this workaround in v4 and use operation-id in line-openapi.
     ## This workaround is to avoid breaking change in v3.
-
-    ## GET    /liff/v1/apps          <- getAllLIFFApps
-    replace_liff_function_name('get_all_liff_apps', 'liff_v1_apps_get')
-    ## POST   /liff/v1/apps          <- addLIFFApp
-    replace_liff_function_name('add_liff_app', 'liff_v1_apps_post')
-    ## PUT    /liff/v1/apps/{liffId} <- updateLIFFApp
-    replace_liff_function_name('update_liff_app', 'liff_v1_apps_liff_id_put')
-    ## DELETE /liff/v1/apps/{liffId} <- deleteLIFFApp
-    replace_liff_function_name('delete_liff_app', 'liff_v1_apps_liff_id_delete')
+    rewrite_liff_function_name_backward_compats()
 
 
 if __name__ == "__main__":

--- a/generate-code.py
+++ b/generate-code.py
@@ -88,8 +88,7 @@ def main():
     run_command(command)
 
 
-    ## TODO(v4): Delete this workaround in v4 and use operation-id in line-openapi.
-    ## This workaround is to avoid breaking change in v3.
+    ## TODO(v4): Delete this workaround in v4. This workaround keeps backward compatibility.
     rewrite_liff_function_name_backward_compats()
 
 

--- a/linebot/v3/liff/api/async_liff.py
+++ b/linebot/v3/liff/api/async_liff.py
@@ -48,24 +48,26 @@ class AsyncLiff(object):
         self.api_client = api_client
 
     @overload
-    async def liff_v1_apps_get(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
+    async def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
         ...
 
     @overload
-    def liff_v1_apps_get(self, async_req: Optional[bool]=True, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
+    def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> AddLiffAppResponse:  # noqa: E501
         ...
 
     @validate_arguments
-    def liff_v1_apps_get(self, async_req: Optional[bool]=None, **kwargs) -> Union[GetAllLiffAppsResponse, Awaitable[GetAllLiffAppsResponse]]:  # noqa: E501
-        """Get all LIFF apps  # noqa: E501
+    def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[AddLiffAppResponse, Awaitable[AddLiffAppResponse]]:  # noqa: E501
+        """add_liff_app  # noqa: E501
 
-        Gets information on all the LIFF apps added to the channel.  # noqa: E501
+        Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_get(async_req=True)
+        >>> thread = api.add_liff_app(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
+        :param add_liff_app_request: (required)
+        :type add_liff_app_request: AddLiffAppRequest
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request. If one
@@ -75,26 +77,28 @@ class AsyncLiff(object):
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: GetAllLiffAppsResponse
+        :rtype: AddLiffAppResponse
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the add_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.liff_v1_apps_get_with_http_info(**kwargs)  # noqa: E501
+        return self.add_liff_app_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
-        """Get all LIFF apps  # noqa: E501
+    def add_liff_app_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """add_liff_app  # noqa: E501
 
-        Gets information on all the LIFF apps added to the channel.  # noqa: E501
+        Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_get_with_http_info(async_req=True)
+        >>> thread = api.add_liff_app_with_http_info(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
+        :param add_liff_app_request: (required)
+        :type add_liff_app_request: AddLiffAppRequest
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
@@ -117,12 +121,13 @@ class AsyncLiff(object):
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(GetAllLiffAppsResponse, status_code(int), headers(HTTPHeaderDict))
+        :rtype: tuple(AddLiffAppResponse, status_code(int), headers(HTTPHeaderDict))
         """
 
         _params = locals()
 
         _all_params = [
+            'add_liff_app_request'
         ]
         _all_params.extend(
             [
@@ -141,7 +146,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_get" % _key
+                    " to method add_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -160,21 +165,31 @@ class AsyncLiff(object):
         _files = {}
         # process the body parameter
         _body_params = None
+        if _params['add_liff_app_request'] is not None:
+            _body_params = _params['add_liff_app_request']
+
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501
+
+        # set the HTTP header `Content-Type`
+        _content_types_list = _params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json']))
+        if _content_types_list:
+                _header_params['Content-Type'] = _content_types_list
 
         # authentication setting
         _auth_settings = ['Bearer']  # noqa: E501
 
         _response_types_map = {
-            '200': "GetAllLiffAppsResponse",
+            '200': "AddLiffAppResponse",
+            '400': None,
             '401': None,
-            '404': None,
         }
 
         return self.api_client.call_api(
-            '/liff/v1/apps', 'GET',
+            '/liff/v1/apps', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -191,22 +206,22 @@ class AsyncLiff(object):
             _request_auth=_params.get('_request_auth'))
 
     @overload
-    async def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
+    async def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
         ...
 
     @overload
-    def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+    def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
     @validate_arguments
-    def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_delete(liff_id, async_req=True)
+        >>> thread = api.delete_liff_app(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -224,20 +239,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_liff_id_delete_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the delete_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.liff_v1_apps_liff_id_delete_with_http_info(liff_id, **kwargs)  # noqa: E501
+        return self.delete_liff_app_with_http_info(liff_id, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_liff_id_delete_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
+    def delete_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_delete_with_http_info(liff_id, async_req=True)
+        >>> thread = api.delete_liff_app_with_http_info(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -289,7 +304,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_liff_id_delete" % _key
+                    " to method delete_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -334,22 +349,165 @@ class AsyncLiff(object):
             _request_auth=_params.get('_request_auth'))
 
     @overload
-    async def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
+    async def get_all_liff_apps(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
         ...
 
     @overload
-    def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+    def get_all_liff_apps(self, async_req: Optional[bool]=True, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
         ...
 
     @validate_arguments
-    def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
-        """liff_v1_apps_liff_id_put  # noqa: E501
+    def get_all_liff_apps(self, async_req: Optional[bool]=None, **kwargs) -> Union[GetAllLiffAppsResponse, Awaitable[GetAllLiffAppsResponse]]:  # noqa: E501
+        """Get all LIFF apps  # noqa: E501
+
+        Gets information on all the LIFF apps added to the channel.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.get_all_liff_apps(async_req=True)
+        >>> result = thread.get()
+
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: GetAllLiffAppsResponse
+        """
+        kwargs['_return_http_data_only'] = True
+        if '_preload_content' in kwargs:
+            raise ValueError("Error! Please call the get_all_liff_apps_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        if async_req is not None:
+            kwargs['async_req'] = async_req
+        return self.get_all_liff_apps_with_http_info(**kwargs)  # noqa: E501
+
+    @validate_arguments
+    def get_all_liff_apps_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+        """Get all LIFF apps  # noqa: E501
+
+        Gets information on all the LIFF apps added to the channel.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.get_all_liff_apps_with_http_info(async_req=True)
+        >>> result = thread.get()
+
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _preload_content: if False, the ApiResponse.data will
+                                 be set to none and raw_data will store the
+                                 HTTP response body without reading/decoding.
+                                 Default is True.
+        :type _preload_content: bool, optional
+        :param _return_http_data_only: response data instead of ApiResponse
+                                       object with status code, headers, etc
+        :type _return_http_data_only: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
+        :type _content_type: string, optional: force content-type for the request
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: tuple(GetAllLiffAppsResponse, status_code(int), headers(HTTPHeaderDict))
+        """
+
+        _params = locals()
+
+        _all_params = [
+        ]
+        _all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout',
+                '_request_auth',
+                '_content_type',
+                '_headers'
+            ]
+        )
+
+        # validate the arguments
+        for _key, _val in _params['kwargs'].items():
+            if _key not in _all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_all_liff_apps" % _key
+                )
+            _params[_key] = _val
+        del _params['kwargs']
+
+        _collection_formats = {}
+
+        # process the path parameters
+        _path_params = {}
+
+        # process the query parameters
+        _query_params = []
+        # process the header parameters
+        _header_params = dict(_params.get('_headers', {}))
+        # process the form parameters
+        _form_params = []
+        _files = {}
+        # process the body parameter
+        _body_params = None
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # authentication setting
+        _auth_settings = ['Bearer']  # noqa: E501
+
+        _response_types_map = {
+            '200': "GetAllLiffAppsResponse",
+            '401': None,
+            '404': None,
+        }
+
+        return self.api_client.call_api(
+            '/liff/v1/apps', 'GET',
+            _path_params,
+            _query_params,
+            _header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            response_types_map=_response_types_map,
+            auth_settings=_auth_settings,
+            async_req=_params.get('async_req'),
+            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=_params.get('_preload_content', True),
+            _request_timeout=_params.get('_request_timeout'),
+            collection_formats=_collection_formats,
+            _request_auth=_params.get('_request_auth'))
+
+    @overload
+    async def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @validate_arguments
+    def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+        """update_liff_app  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_put(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.update_liff_app(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -369,20 +527,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_liff_id_put_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the update_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
+        return self.update_liff_app_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_liff_id_put_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """liff_v1_apps_liff_id_put  # noqa: E501
+    def update_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """update_liff_app  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.update_liff_app_with_http_info(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -437,7 +595,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_liff_id_put" % _key
+                    " to method update_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -476,164 +634,6 @@ class AsyncLiff(object):
 
         return self.api_client.call_api(
             '/liff/v1/apps/{liffId}', 'PUT',
-            _path_params,
-            _query_params,
-            _header_params,
-            body=_body_params,
-            post_params=_form_params,
-            files=_files,
-            response_types_map=_response_types_map,
-            auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
-            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
-            _preload_content=_params.get('_preload_content', True),
-            _request_timeout=_params.get('_request_timeout'),
-            collection_formats=_collection_formats,
-            _request_auth=_params.get('_request_auth'))
-
-    @overload
-    async def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
-        ...
-
-    @overload
-    def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> AddLiffAppResponse:  # noqa: E501
-        ...
-
-    @validate_arguments
-    def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[AddLiffAppResponse, Awaitable[AddLiffAppResponse]]:  # noqa: E501
-        """liff_v1_apps_post  # noqa: E501
-
-        Adding the LIFF app to a channel  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.liff_v1_apps_post(add_liff_app_request, async_req=True)
-        >>> result = thread.get()
-
-        :param add_liff_app_request: (required)
-        :type add_liff_app_request: AddLiffAppRequest
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :return: Returns the result object.
-                 If the method is called asynchronously,
-                 returns the request thread.
-        :rtype: AddLiffAppResponse
-        """
-        kwargs['_return_http_data_only'] = True
-        if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_post_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.liff_v1_apps_post_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
-
-    @validate_arguments
-    def liff_v1_apps_post_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """liff_v1_apps_post  # noqa: E501
-
-        Adding the LIFF app to a channel  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.liff_v1_apps_post_with_http_info(add_liff_app_request, async_req=True)
-        >>> result = thread.get()
-
-        :param add_liff_app_request: (required)
-        :type add_liff_app_request: AddLiffAppRequest
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
-                                 Default is True.
-        :type _preload_content: bool, optional
-        :param _return_http_data_only: response data instead of ApiResponse
-                                       object with status code, headers, etc
-        :type _return_http_data_only: bool, optional
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the authentication
-                              in the spec for a single request.
-        :type _request_auth: dict, optional
-        :type _content_type: string, optional: force content-type for the request
-        :return: Returns the result object.
-                 If the method is called asynchronously,
-                 returns the request thread.
-        :rtype: tuple(AddLiffAppResponse, status_code(int), headers(HTTPHeaderDict))
-        """
-
-        _params = locals()
-
-        _all_params = [
-            'add_liff_app_request'
-        ]
-        _all_params.extend(
-            [
-                'async_req',
-                '_return_http_data_only',
-                '_preload_content',
-                '_request_timeout',
-                '_request_auth',
-                '_content_type',
-                '_headers'
-            ]
-        )
-
-        # validate the arguments
-        for _key, _val in _params['kwargs'].items():
-            if _key not in _all_params:
-                raise ApiTypeError(
-                    "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_post" % _key
-                )
-            _params[_key] = _val
-        del _params['kwargs']
-
-        _collection_formats = {}
-
-        # process the path parameters
-        _path_params = {}
-
-        # process the query parameters
-        _query_params = []
-        # process the header parameters
-        _header_params = dict(_params.get('_headers', {}))
-        # process the form parameters
-        _form_params = []
-        _files = {}
-        # process the body parameter
-        _body_params = None
-        if _params['add_liff_app_request'] is not None:
-            _body_params = _params['add_liff_app_request']
-
-        # set the HTTP header `Accept`
-        _header_params['Accept'] = self.api_client.select_header_accept(
-            ['application/json'])  # noqa: E501
-
-        # set the HTTP header `Content-Type`
-        _content_types_list = _params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json']))
-        if _content_types_list:
-                _header_params['Content-Type'] = _content_types_list
-
-        # authentication setting
-        _auth_settings = ['Bearer']  # noqa: E501
-
-        _response_types_map = {
-            '200': "AddLiffAppResponse",
-            '400': None,
-            '401': None,
-        }
-
-        return self.api_client.call_api(
-            '/liff/v1/apps', 'POST',
             _path_params,
             _query_params,
             _header_params,

--- a/linebot/v3/liff/api/async_liff.py
+++ b/linebot/v3/liff/api/async_liff.py
@@ -48,22 +48,22 @@ class AsyncLiff(object):
         self.api_client = api_client
 
     @overload
-    async def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
+    async def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
         ...
 
     @overload
-    def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> AddLiffAppResponse:  # noqa: E501
+    def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> AddLiffAppResponse:  # noqa: E501
         ...
 
     @validate_arguments
-    def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[AddLiffAppResponse, Awaitable[AddLiffAppResponse]]:  # noqa: E501
-        """add_liff_app  # noqa: E501
+    def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[AddLiffAppResponse, Awaitable[AddLiffAppResponse]]:  # noqa: E501
+        """liff_v1_apps_post  # noqa: E501
 
         Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.add_liff_app(add_liff_app_request, async_req=True)
+        >>> thread = api.liff_v1_apps_post(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param add_liff_app_request: (required)
@@ -81,20 +81,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the add_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the liff_v1_apps_post_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.add_liff_app_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
+        return self.liff_v1_apps_post_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def add_liff_app_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """add_liff_app  # noqa: E501
+    def liff_v1_apps_post_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """liff_v1_apps_post  # noqa: E501
 
         Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.add_liff_app_with_http_info(add_liff_app_request, async_req=True)
+        >>> thread = api.liff_v1_apps_post_with_http_info(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param add_liff_app_request: (required)
@@ -146,7 +146,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method add_liff_app" % _key
+                    " to method liff_v1_apps_post" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -206,22 +206,22 @@ class AsyncLiff(object):
             _request_auth=_params.get('_request_auth'))
 
     @overload
-    async def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
+    async def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
         ...
 
     @overload
-    def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+    def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
     @validate_arguments
-    def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.delete_liff_app(liff_id, async_req=True)
+        >>> thread = api.liff_v1_apps_liff_id_delete(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -239,20 +239,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the delete_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the liff_v1_apps_liff_id_delete_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.delete_liff_app_with_http_info(liff_id, **kwargs)  # noqa: E501
+        return self.liff_v1_apps_liff_id_delete_with_http_info(liff_id, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def delete_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
+    def liff_v1_apps_liff_id_delete_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.delete_liff_app_with_http_info(liff_id, async_req=True)
+        >>> thread = api.liff_v1_apps_liff_id_delete_with_http_info(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -304,7 +304,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method delete_liff_app" % _key
+                    " to method liff_v1_apps_liff_id_delete" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -349,22 +349,22 @@ class AsyncLiff(object):
             _request_auth=_params.get('_request_auth'))
 
     @overload
-    async def get_all_liff_apps(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
+    async def liff_v1_apps_get(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
         ...
 
     @overload
-    def get_all_liff_apps(self, async_req: Optional[bool]=True, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
+    def liff_v1_apps_get(self, async_req: Optional[bool]=True, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
         ...
 
     @validate_arguments
-    def get_all_liff_apps(self, async_req: Optional[bool]=None, **kwargs) -> Union[GetAllLiffAppsResponse, Awaitable[GetAllLiffAppsResponse]]:  # noqa: E501
+    def liff_v1_apps_get(self, async_req: Optional[bool]=None, **kwargs) -> Union[GetAllLiffAppsResponse, Awaitable[GetAllLiffAppsResponse]]:  # noqa: E501
         """Get all LIFF apps  # noqa: E501
 
         Gets information on all the LIFF apps added to the channel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.get_all_liff_apps(async_req=True)
+        >>> thread = api.liff_v1_apps_get(async_req=True)
         >>> result = thread.get()
 
         :param async_req: Whether to execute the request asynchronously.
@@ -380,20 +380,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the get_all_liff_apps_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the liff_v1_apps_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.get_all_liff_apps_with_http_info(**kwargs)  # noqa: E501
+        return self.liff_v1_apps_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
-    def get_all_liff_apps_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def liff_v1_apps_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Get all LIFF apps  # noqa: E501
 
         Gets information on all the LIFF apps added to the channel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.get_all_liff_apps_with_http_info(async_req=True)
+        >>> thread = api.liff_v1_apps_get_with_http_info(async_req=True)
         >>> result = thread.get()
 
         :param async_req: Whether to execute the request asynchronously.
@@ -442,7 +442,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method get_all_liff_apps" % _key
+                    " to method liff_v1_apps_get" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -492,22 +492,22 @@ class AsyncLiff(object):
             _request_auth=_params.get('_request_auth'))
 
     @overload
-    async def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
+    async def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
         ...
 
     @overload
-    def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+    def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
     @validate_arguments
-    def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
-        """update_liff_app  # noqa: E501
+    def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+        """liff_v1_apps_liff_id_put  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.update_liff_app(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.liff_v1_apps_liff_id_put(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -527,20 +527,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the update_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the liff_v1_apps_liff_id_put_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.update_liff_app_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
+        return self.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def update_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """update_liff_app  # noqa: E501
+    def liff_v1_apps_liff_id_put_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """liff_v1_apps_liff_id_put  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.update_liff_app_with_http_info(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -595,7 +595,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method update_liff_app" % _key
+                    " to method liff_v1_apps_liff_id_put" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']

--- a/linebot/v3/liff/api/async_liff.py
+++ b/linebot/v3/liff/api/async_liff.py
@@ -48,22 +48,22 @@ class AsyncLiff(object):
         self.api_client = api_client
 
     @overload
-    async def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
+    async def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
         ...
 
     @overload
-    def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> AddLiffAppResponse:  # noqa: E501
+    def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> AddLiffAppResponse:  # noqa: E501
         ...
 
     @validate_arguments
-    def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[AddLiffAppResponse, Awaitable[AddLiffAppResponse]]:  # noqa: E501
-        """liff_v1_apps_post  # noqa: E501
+    def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[AddLiffAppResponse, Awaitable[AddLiffAppResponse]]:  # noqa: E501
+        """add_liff_app  # noqa: E501
 
         Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_post(add_liff_app_request, async_req=True)
+        >>> thread = api.add_liff_app(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param add_liff_app_request: (required)
@@ -81,20 +81,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_post_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the add_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.liff_v1_apps_post_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
+        return self.add_liff_app_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_post_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """liff_v1_apps_post  # noqa: E501
+    def add_liff_app_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """add_liff_app  # noqa: E501
 
         Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_post_with_http_info(add_liff_app_request, async_req=True)
+        >>> thread = api.add_liff_app_with_http_info(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param add_liff_app_request: (required)
@@ -146,7 +146,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_post" % _key
+                    " to method add_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -206,22 +206,22 @@ class AsyncLiff(object):
             _request_auth=_params.get('_request_auth'))
 
     @overload
-    async def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
+    async def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
         ...
 
     @overload
-    def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+    def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
     @validate_arguments
-    def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_delete(liff_id, async_req=True)
+        >>> thread = api.delete_liff_app(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -239,20 +239,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_liff_id_delete_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the delete_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.liff_v1_apps_liff_id_delete_with_http_info(liff_id, **kwargs)  # noqa: E501
+        return self.delete_liff_app_with_http_info(liff_id, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_liff_id_delete_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
+    def delete_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_delete_with_http_info(liff_id, async_req=True)
+        >>> thread = api.delete_liff_app_with_http_info(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -304,7 +304,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_liff_id_delete" % _key
+                    " to method delete_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -349,22 +349,22 @@ class AsyncLiff(object):
             _request_auth=_params.get('_request_auth'))
 
     @overload
-    async def liff_v1_apps_get(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
+    async def get_all_liff_apps(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
         ...
 
     @overload
-    def liff_v1_apps_get(self, async_req: Optional[bool]=True, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
+    def get_all_liff_apps(self, async_req: Optional[bool]=True, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
         ...
 
     @validate_arguments
-    def liff_v1_apps_get(self, async_req: Optional[bool]=None, **kwargs) -> Union[GetAllLiffAppsResponse, Awaitable[GetAllLiffAppsResponse]]:  # noqa: E501
+    def get_all_liff_apps(self, async_req: Optional[bool]=None, **kwargs) -> Union[GetAllLiffAppsResponse, Awaitable[GetAllLiffAppsResponse]]:  # noqa: E501
         """Get all LIFF apps  # noqa: E501
 
         Gets information on all the LIFF apps added to the channel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_get(async_req=True)
+        >>> thread = api.get_all_liff_apps(async_req=True)
         >>> result = thread.get()
 
         :param async_req: Whether to execute the request asynchronously.
@@ -380,20 +380,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the get_all_liff_apps_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.liff_v1_apps_get_with_http_info(**kwargs)  # noqa: E501
+        return self.get_all_liff_apps_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def get_all_liff_apps_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Get all LIFF apps  # noqa: E501
 
         Gets information on all the LIFF apps added to the channel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_get_with_http_info(async_req=True)
+        >>> thread = api.get_all_liff_apps_with_http_info(async_req=True)
         >>> result = thread.get()
 
         :param async_req: Whether to execute the request asynchronously.
@@ -442,7 +442,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_get" % _key
+                    " to method get_all_liff_apps" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -492,22 +492,22 @@ class AsyncLiff(object):
             _request_auth=_params.get('_request_auth'))
 
     @overload
-    async def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
+    async def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
         ...
 
     @overload
-    def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+    def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
     @validate_arguments
-    def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
-        """liff_v1_apps_liff_id_put  # noqa: E501
+    def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+        """update_liff_app  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_put(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.update_liff_app(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -527,20 +527,20 @@ class AsyncLiff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_liff_id_put_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+            raise ValueError("Error! Please call the update_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         if async_req is not None:
             kwargs['async_req'] = async_req
-        return self.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
+        return self.update_liff_app_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_liff_id_put_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """liff_v1_apps_liff_id_put  # noqa: E501
+    def update_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """update_liff_app  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.update_liff_app_with_http_info(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -595,7 +595,7 @@ class AsyncLiff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_liff_id_put" % _key
+                    " to method update_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -648,3 +648,45 @@ class AsyncLiff(object):
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
+
+
+
+    def liff_v1_apps_get(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_get was deprecated. use get_all_liff_apps instead.', DeprecationWarning)
+        return self.get_all_liff_apps(*args, **kwargs)
+
+    def liff_v1_apps_get_with_http_info(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_get_with_http_info was deprecated. use get_all_liff_apps_with_http_info instead.', DeprecationWarning)
+        return self.get_all_liff_apps_with_http_info(*args, **kwargs)
+
+    def liff_v1_apps_post(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_post was deprecated. use add_liff_app instead.', DeprecationWarning)
+        return self.add_liff_app(*args, **kwargs)
+
+    def liff_v1_apps_post_with_http_info(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_post_with_http_info was deprecated. use add_liff_app_with_http_info instead.', DeprecationWarning)
+        return self.add_liff_app_with_http_info(*args, **kwargs)
+
+    def liff_v1_apps_liff_id_put(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_liff_id_put was deprecated. use update_liff_app instead.', DeprecationWarning)
+        return self.update_liff_app(*args, **kwargs)
+
+    def liff_v1_apps_liff_id_put_with_http_info(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_liff_id_put_with_http_info was deprecated. use update_liff_app_with_http_info instead.', DeprecationWarning)
+        return self.update_liff_app_with_http_info(*args, **kwargs)
+
+    def liff_v1_apps_liff_id_delete(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_liff_id_delete was deprecated. use delete_liff_app instead.', DeprecationWarning)
+        return self.delete_liff_app(*args, **kwargs)
+
+    def liff_v1_apps_liff_id_delete_with_http_info(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_liff_id_delete_with_http_info was deprecated. use delete_liff_app_with_http_info instead.', DeprecationWarning)
+        return self.delete_liff_app_with_http_info(*args, **kwargs)

--- a/linebot/v3/liff/api/liff.py
+++ b/linebot/v3/liff/api/liff.py
@@ -46,14 +46,14 @@ class Liff(object):
         self.api_client = api_client
 
     @validate_arguments
-    def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
-        """add_liff_app  # noqa: E501
+    def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
+        """liff_v1_apps_post  # noqa: E501
 
         Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.add_liff_app(add_liff_app_request, async_req=True)
+        >>> thread = api.liff_v1_apps_post(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param add_liff_app_request: (required)
@@ -71,18 +71,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the add_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.add_liff_app_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the liff_v1_apps_post_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.liff_v1_apps_post_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def add_liff_app_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """add_liff_app  # noqa: E501
+    def liff_v1_apps_post_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """liff_v1_apps_post  # noqa: E501
 
         Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.add_liff_app_with_http_info(add_liff_app_request, async_req=True)
+        >>> thread = api.liff_v1_apps_post_with_http_info(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param add_liff_app_request: (required)
@@ -134,7 +134,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method add_liff_app" % _key
+                    " to method liff_v1_apps_post" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -194,14 +194,14 @@ class Liff(object):
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
-    def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
+    def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.delete_liff_app(liff_id, async_req=True)
+        >>> thread = api.liff_v1_apps_liff_id_delete(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -219,18 +219,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the delete_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.delete_liff_app_with_http_info(liff_id, **kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the liff_v1_apps_liff_id_delete_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.liff_v1_apps_liff_id_delete_with_http_info(liff_id, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def delete_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
+    def liff_v1_apps_liff_id_delete_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.delete_liff_app_with_http_info(liff_id, async_req=True)
+        >>> thread = api.liff_v1_apps_liff_id_delete_with_http_info(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -282,7 +282,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method delete_liff_app" % _key
+                    " to method liff_v1_apps_liff_id_delete" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -327,14 +327,14 @@ class Liff(object):
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
-    def get_all_liff_apps(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
+    def liff_v1_apps_get(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
         """Get all LIFF apps  # noqa: E501
 
         Gets information on all the LIFF apps added to the channel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.get_all_liff_apps(async_req=True)
+        >>> thread = api.liff_v1_apps_get(async_req=True)
         >>> result = thread.get()
 
         :param async_req: Whether to execute the request asynchronously.
@@ -350,18 +350,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the get_all_liff_apps_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.get_all_liff_apps_with_http_info(**kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the liff_v1_apps_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.liff_v1_apps_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
-    def get_all_liff_apps_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def liff_v1_apps_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Get all LIFF apps  # noqa: E501
 
         Gets information on all the LIFF apps added to the channel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.get_all_liff_apps_with_http_info(async_req=True)
+        >>> thread = api.liff_v1_apps_get_with_http_info(async_req=True)
         >>> result = thread.get()
 
         :param async_req: Whether to execute the request asynchronously.
@@ -410,7 +410,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method get_all_liff_apps" % _key
+                    " to method liff_v1_apps_get" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -460,14 +460,14 @@ class Liff(object):
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
-    def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
-        """update_liff_app  # noqa: E501
+    def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
+        """liff_v1_apps_liff_id_put  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.update_liff_app(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.liff_v1_apps_liff_id_put(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -487,18 +487,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the update_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.update_liff_app_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the liff_v1_apps_liff_id_put_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def update_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """update_liff_app  # noqa: E501
+    def liff_v1_apps_liff_id_put_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """liff_v1_apps_liff_id_put  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.update_liff_app_with_http_info(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -553,7 +553,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method update_liff_app" % _key
+                    " to method liff_v1_apps_liff_id_put" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']

--- a/linebot/v3/liff/api/liff.py
+++ b/linebot/v3/liff/api/liff.py
@@ -46,16 +46,18 @@ class Liff(object):
         self.api_client = api_client
 
     @validate_arguments
-    def liff_v1_apps_get(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
-        """Get all LIFF apps  # noqa: E501
+    def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
+        """add_liff_app  # noqa: E501
 
-        Gets information on all the LIFF apps added to the channel.  # noqa: E501
+        Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_get(async_req=True)
+        >>> thread = api.add_liff_app(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
+        :param add_liff_app_request: (required)
+        :type add_liff_app_request: AddLiffAppRequest
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request. If one
@@ -65,24 +67,26 @@ class Liff(object):
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: GetAllLiffAppsResponse
+        :rtype: AddLiffAppResponse
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.liff_v1_apps_get_with_http_info(**kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the add_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.add_liff_app_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
-        """Get all LIFF apps  # noqa: E501
+    def add_liff_app_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """add_liff_app  # noqa: E501
 
-        Gets information on all the LIFF apps added to the channel.  # noqa: E501
+        Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_get_with_http_info(async_req=True)
+        >>> thread = api.add_liff_app_with_http_info(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
+        :param add_liff_app_request: (required)
+        :type add_liff_app_request: AddLiffAppRequest
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
@@ -105,12 +109,13 @@ class Liff(object):
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(GetAllLiffAppsResponse, status_code(int), headers(HTTPHeaderDict))
+        :rtype: tuple(AddLiffAppResponse, status_code(int), headers(HTTPHeaderDict))
         """
 
         _params = locals()
 
         _all_params = [
+            'add_liff_app_request'
         ]
         _all_params.extend(
             [
@@ -129,7 +134,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_get" % _key
+                    " to method add_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -148,21 +153,31 @@ class Liff(object):
         _files = {}
         # process the body parameter
         _body_params = None
+        if _params['add_liff_app_request'] is not None:
+            _body_params = _params['add_liff_app_request']
+
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501
+
+        # set the HTTP header `Content-Type`
+        _content_types_list = _params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json']))
+        if _content_types_list:
+                _header_params['Content-Type'] = _content_types_list
 
         # authentication setting
         _auth_settings = ['Bearer']  # noqa: E501
 
         _response_types_map = {
-            '200': "GetAllLiffAppsResponse",
+            '200': "AddLiffAppResponse",
+            '400': None,
             '401': None,
-            '404': None,
         }
 
         return self.api_client.call_api(
-            '/liff/v1/apps', 'GET',
+            '/liff/v1/apps', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -179,14 +194,14 @@ class Liff(object):
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
-    def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
+    def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_delete(liff_id, async_req=True)
+        >>> thread = api.delete_liff_app(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -204,18 +219,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_liff_id_delete_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.liff_v1_apps_liff_id_delete_with_http_info(liff_id, **kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the delete_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.delete_liff_app_with_http_info(liff_id, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_liff_id_delete_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
+    def delete_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_delete_with_http_info(liff_id, async_req=True)
+        >>> thread = api.delete_liff_app_with_http_info(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -267,7 +282,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_liff_id_delete" % _key
+                    " to method delete_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -312,14 +327,147 @@ class Liff(object):
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
-    def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
-        """liff_v1_apps_liff_id_put  # noqa: E501
+    def get_all_liff_apps(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
+        """Get all LIFF apps  # noqa: E501
+
+        Gets information on all the LIFF apps added to the channel.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.get_all_liff_apps(async_req=True)
+        >>> result = thread.get()
+
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: GetAllLiffAppsResponse
+        """
+        kwargs['_return_http_data_only'] = True
+        if '_preload_content' in kwargs:
+            raise ValueError("Error! Please call the get_all_liff_apps_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.get_all_liff_apps_with_http_info(**kwargs)  # noqa: E501
+
+    @validate_arguments
+    def get_all_liff_apps_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+        """Get all LIFF apps  # noqa: E501
+
+        Gets information on all the LIFF apps added to the channel.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.get_all_liff_apps_with_http_info(async_req=True)
+        >>> result = thread.get()
+
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _preload_content: if False, the ApiResponse.data will
+                                 be set to none and raw_data will store the
+                                 HTTP response body without reading/decoding.
+                                 Default is True.
+        :type _preload_content: bool, optional
+        :param _return_http_data_only: response data instead of ApiResponse
+                                       object with status code, headers, etc
+        :type _return_http_data_only: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
+        :type _content_type: string, optional: force content-type for the request
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: tuple(GetAllLiffAppsResponse, status_code(int), headers(HTTPHeaderDict))
+        """
+
+        _params = locals()
+
+        _all_params = [
+        ]
+        _all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout',
+                '_request_auth',
+                '_content_type',
+                '_headers'
+            ]
+        )
+
+        # validate the arguments
+        for _key, _val in _params['kwargs'].items():
+            if _key not in _all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_all_liff_apps" % _key
+                )
+            _params[_key] = _val
+        del _params['kwargs']
+
+        _collection_formats = {}
+
+        # process the path parameters
+        _path_params = {}
+
+        # process the query parameters
+        _query_params = []
+        # process the header parameters
+        _header_params = dict(_params.get('_headers', {}))
+        # process the form parameters
+        _form_params = []
+        _files = {}
+        # process the body parameter
+        _body_params = None
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # authentication setting
+        _auth_settings = ['Bearer']  # noqa: E501
+
+        _response_types_map = {
+            '200': "GetAllLiffAppsResponse",
+            '401': None,
+            '404': None,
+        }
+
+        return self.api_client.call_api(
+            '/liff/v1/apps', 'GET',
+            _path_params,
+            _query_params,
+            _header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            response_types_map=_response_types_map,
+            auth_settings=_auth_settings,
+            async_req=_params.get('async_req'),
+            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=_params.get('_preload_content', True),
+            _request_timeout=_params.get('_request_timeout'),
+            collection_formats=_collection_formats,
+            _request_auth=_params.get('_request_auth'))
+
+    @validate_arguments
+    def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
+        """update_liff_app  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_put(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.update_liff_app(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -339,18 +487,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_liff_id_put_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the update_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.update_liff_app_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_liff_id_put_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """liff_v1_apps_liff_id_put  # noqa: E501
+    def update_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """update_liff_app  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.update_liff_app_with_http_info(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -405,7 +553,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_liff_id_put" % _key
+                    " to method update_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -444,154 +592,6 @@ class Liff(object):
 
         return self.api_client.call_api(
             '/liff/v1/apps/{liffId}', 'PUT',
-            _path_params,
-            _query_params,
-            _header_params,
-            body=_body_params,
-            post_params=_form_params,
-            files=_files,
-            response_types_map=_response_types_map,
-            auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
-            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
-            _preload_content=_params.get('_preload_content', True),
-            _request_timeout=_params.get('_request_timeout'),
-            collection_formats=_collection_formats,
-            _request_auth=_params.get('_request_auth'))
-
-    @validate_arguments
-    def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
-        """liff_v1_apps_post  # noqa: E501
-
-        Adding the LIFF app to a channel  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.liff_v1_apps_post(add_liff_app_request, async_req=True)
-        >>> result = thread.get()
-
-        :param add_liff_app_request: (required)
-        :type add_liff_app_request: AddLiffAppRequest
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :return: Returns the result object.
-                 If the method is called asynchronously,
-                 returns the request thread.
-        :rtype: AddLiffAppResponse
-        """
-        kwargs['_return_http_data_only'] = True
-        if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_post_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.liff_v1_apps_post_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
-
-    @validate_arguments
-    def liff_v1_apps_post_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """liff_v1_apps_post  # noqa: E501
-
-        Adding the LIFF app to a channel  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.liff_v1_apps_post_with_http_info(add_liff_app_request, async_req=True)
-        >>> result = thread.get()
-
-        :param add_liff_app_request: (required)
-        :type add_liff_app_request: AddLiffAppRequest
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
-                                 Default is True.
-        :type _preload_content: bool, optional
-        :param _return_http_data_only: response data instead of ApiResponse
-                                       object with status code, headers, etc
-        :type _return_http_data_only: bool, optional
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the authentication
-                              in the spec for a single request.
-        :type _request_auth: dict, optional
-        :type _content_type: string, optional: force content-type for the request
-        :return: Returns the result object.
-                 If the method is called asynchronously,
-                 returns the request thread.
-        :rtype: tuple(AddLiffAppResponse, status_code(int), headers(HTTPHeaderDict))
-        """
-
-        _params = locals()
-
-        _all_params = [
-            'add_liff_app_request'
-        ]
-        _all_params.extend(
-            [
-                'async_req',
-                '_return_http_data_only',
-                '_preload_content',
-                '_request_timeout',
-                '_request_auth',
-                '_content_type',
-                '_headers'
-            ]
-        )
-
-        # validate the arguments
-        for _key, _val in _params['kwargs'].items():
-            if _key not in _all_params:
-                raise ApiTypeError(
-                    "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_post" % _key
-                )
-            _params[_key] = _val
-        del _params['kwargs']
-
-        _collection_formats = {}
-
-        # process the path parameters
-        _path_params = {}
-
-        # process the query parameters
-        _query_params = []
-        # process the header parameters
-        _header_params = dict(_params.get('_headers', {}))
-        # process the form parameters
-        _form_params = []
-        _files = {}
-        # process the body parameter
-        _body_params = None
-        if _params['add_liff_app_request'] is not None:
-            _body_params = _params['add_liff_app_request']
-
-        # set the HTTP header `Accept`
-        _header_params['Accept'] = self.api_client.select_header_accept(
-            ['application/json'])  # noqa: E501
-
-        # set the HTTP header `Content-Type`
-        _content_types_list = _params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json']))
-        if _content_types_list:
-                _header_params['Content-Type'] = _content_types_list
-
-        # authentication setting
-        _auth_settings = ['Bearer']  # noqa: E501
-
-        _response_types_map = {
-            '200': "AddLiffAppResponse",
-            '400': None,
-            '401': None,
-        }
-
-        return self.api_client.call_api(
-            '/liff/v1/apps', 'POST',
             _path_params,
             _query_params,
             _header_params,

--- a/linebot/v3/liff/api/liff.py
+++ b/linebot/v3/liff/api/liff.py
@@ -46,14 +46,14 @@ class Liff(object):
         self.api_client = api_client
 
     @validate_arguments
-    def liff_v1_apps_post(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
-        """liff_v1_apps_post  # noqa: E501
+    def add_liff_app(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> AddLiffAppResponse:  # noqa: E501
+        """add_liff_app  # noqa: E501
 
         Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_post(add_liff_app_request, async_req=True)
+        >>> thread = api.add_liff_app(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param add_liff_app_request: (required)
@@ -71,18 +71,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_post_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.liff_v1_apps_post_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the add_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.add_liff_app_with_http_info(add_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_post_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """liff_v1_apps_post  # noqa: E501
+    def add_liff_app_with_http_info(self, add_liff_app_request : AddLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """add_liff_app  # noqa: E501
 
         Adding the LIFF app to a channel  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_post_with_http_info(add_liff_app_request, async_req=True)
+        >>> thread = api.add_liff_app_with_http_info(add_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param add_liff_app_request: (required)
@@ -134,7 +134,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_post" % _key
+                    " to method add_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -194,14 +194,14 @@ class Liff(object):
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
-    def liff_v1_apps_liff_id_delete(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
+    def delete_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> None:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_delete(liff_id, async_req=True)
+        >>> thread = api.delete_liff_app(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -219,18 +219,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_liff_id_delete_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.liff_v1_apps_liff_id_delete_with_http_info(liff_id, **kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the delete_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.delete_liff_app_with_http_info(liff_id, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_liff_id_delete_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
+    def delete_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete LIFF app from a channel  # noqa: E501
 
         Deletes a LIFF app from a channel.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_delete_with_http_info(liff_id, async_req=True)
+        >>> thread = api.delete_liff_app_with_http_info(liff_id, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -282,7 +282,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_liff_id_delete" % _key
+                    " to method delete_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -327,14 +327,14 @@ class Liff(object):
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
-    def liff_v1_apps_get(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
+    def get_all_liff_apps(self, **kwargs) -> GetAllLiffAppsResponse:  # noqa: E501
         """Get all LIFF apps  # noqa: E501
 
         Gets information on all the LIFF apps added to the channel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_get(async_req=True)
+        >>> thread = api.get_all_liff_apps(async_req=True)
         >>> result = thread.get()
 
         :param async_req: Whether to execute the request asynchronously.
@@ -350,18 +350,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.liff_v1_apps_get_with_http_info(**kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the get_all_liff_apps_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.get_all_liff_apps_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def get_all_liff_apps_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Get all LIFF apps  # noqa: E501
 
         Gets information on all the LIFF apps added to the channel.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_get_with_http_info(async_req=True)
+        >>> thread = api.get_all_liff_apps_with_http_info(async_req=True)
         >>> result = thread.get()
 
         :param async_req: Whether to execute the request asynchronously.
@@ -410,7 +410,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_get" % _key
+                    " to method get_all_liff_apps" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -460,14 +460,14 @@ class Liff(object):
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
-    def liff_v1_apps_liff_id_put(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
-        """liff_v1_apps_liff_id_put  # noqa: E501
+    def update_liff_app(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> None:  # noqa: E501
+        """update_liff_app  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_put(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.update_liff_app(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -487,18 +487,18 @@ class Liff(object):
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            raise ValueError("Error! Please call the liff_v1_apps_liff_id_put_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
-        return self.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
+            raise ValueError("Error! Please call the update_liff_app_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.update_liff_app_with_http_info(liff_id, update_liff_app_request, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def liff_v1_apps_liff_id_put_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
-        """liff_v1_apps_liff_id_put  # noqa: E501
+    def update_liff_app_with_http_info(self, liff_id : Annotated[StrictStr, Field(..., description="ID of the LIFF app to be updated")], update_liff_app_request : UpdateLiffAppRequest, **kwargs) -> ApiResponse:  # noqa: E501
+        """update_liff_app  # noqa: E501
 
         Update LIFF app settings  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.liff_v1_apps_liff_id_put_with_http_info(liff_id, update_liff_app_request, async_req=True)
+        >>> thread = api.update_liff_app_with_http_info(liff_id, update_liff_app_request, async_req=True)
         >>> result = thread.get()
 
         :param liff_id: ID of the LIFF app to be updated (required)
@@ -553,7 +553,7 @@ class Liff(object):
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method liff_v1_apps_liff_id_put" % _key
+                    " to method update_liff_app" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -606,3 +606,45 @@ class Liff(object):
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
+
+
+
+    def liff_v1_apps_get(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_get was deprecated. use get_all_liff_apps instead.', DeprecationWarning)
+        return self.get_all_liff_apps(*args, **kwargs)
+
+    def liff_v1_apps_get_with_http_info(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_get_with_http_info was deprecated. use get_all_liff_apps_with_http_info instead.', DeprecationWarning)
+        return self.get_all_liff_apps_with_http_info(*args, **kwargs)
+
+    def liff_v1_apps_post(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_post was deprecated. use add_liff_app instead.', DeprecationWarning)
+        return self.add_liff_app(*args, **kwargs)
+
+    def liff_v1_apps_post_with_http_info(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_post_with_http_info was deprecated. use add_liff_app_with_http_info instead.', DeprecationWarning)
+        return self.add_liff_app_with_http_info(*args, **kwargs)
+
+    def liff_v1_apps_liff_id_put(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_liff_id_put was deprecated. use update_liff_app instead.', DeprecationWarning)
+        return self.update_liff_app(*args, **kwargs)
+
+    def liff_v1_apps_liff_id_put_with_http_info(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_liff_id_put_with_http_info was deprecated. use update_liff_app_with_http_info instead.', DeprecationWarning)
+        return self.update_liff_app_with_http_info(*args, **kwargs)
+
+    def liff_v1_apps_liff_id_delete(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_liff_id_delete was deprecated. use delete_liff_app instead.', DeprecationWarning)
+        return self.delete_liff_app(*args, **kwargs)
+
+    def liff_v1_apps_liff_id_delete_with_http_info(self, *args, **kwargs):
+        import warnings
+        warnings.warn('liff_v1_apps_liff_id_delete_with_http_info was deprecated. use delete_liff_app_with_http_info instead.', DeprecationWarning)
+        return self.delete_liff_app_with_http_info(*args, **kwargs)

--- a/linebot/v3/liff/docs/Liff.md
+++ b/linebot/v3/liff/docs/Liff.md
@@ -4,14 +4,14 @@ All URIs are relative to *https://api.line.me*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**add_liff_app**](Liff.md#add_liff_app) | **POST** /liff/v1/apps | 
-[**delete_liff_app**](Liff.md#delete_liff_app) | **DELETE** /liff/v1/apps/{liffId} | Delete LIFF app from a channel
-[**get_all_liff_apps**](Liff.md#get_all_liff_apps) | **GET** /liff/v1/apps | Get all LIFF apps
-[**update_liff_app**](Liff.md#update_liff_app) | **PUT** /liff/v1/apps/{liffId} | 
+[**liff_v1_apps_post**](Liff.md#liff_v1_apps_post) | **POST** /liff/v1/apps | 
+[**liff_v1_apps_liff_id_delete**](Liff.md#liff_v1_apps_liff_id_delete) | **DELETE** /liff/v1/apps/{liffId} | Delete LIFF app from a channel
+[**liff_v1_apps_get**](Liff.md#liff_v1_apps_get) | **GET** /liff/v1/apps | Get all LIFF apps
+[**liff_v1_apps_liff_id_put**](Liff.md#liff_v1_apps_liff_id_put) | **PUT** /liff/v1/apps/{liffId} | 
 
 
-# **add_liff_app**
-> AddLiffAppResponse add_liff_app(add_liff_app_request)
+# **liff_v1_apps_post**
+> AddLiffAppResponse liff_v1_apps_post(add_liff_app_request)
 
 
 
@@ -52,11 +52,11 @@ with linebot.v3.liff.ApiClient(configuration) as api_client:
     add_liff_app_request = linebot.v3.liff.AddLiffAppRequest() # AddLiffAppRequest | 
 
     try:
-        api_response = api_instance.add_liff_app(add_liff_app_request)
-        print("The response of Liff->add_liff_app:\n")
+        api_response = api_instance.liff_v1_apps_post(add_liff_app_request)
+        print("The response of Liff->liff_v1_apps_post:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling Liff->add_liff_app: %s\n" % e)
+        print("Exception when calling Liff->liff_v1_apps_post: %s\n" % e)
 ```
 
 
@@ -88,8 +88,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **delete_liff_app**
-> delete_liff_app(liff_id)
+# **liff_v1_apps_liff_id_delete**
+> liff_v1_apps_liff_id_delete(liff_id)
 
 Delete LIFF app from a channel
 
@@ -129,9 +129,9 @@ with linebot.v3.liff.ApiClient(configuration) as api_client:
 
     try:
         # Delete LIFF app from a channel
-        api_instance.delete_liff_app(liff_id)
+        api_instance.liff_v1_apps_liff_id_delete(liff_id)
     except Exception as e:
-        print("Exception when calling Liff->delete_liff_app: %s\n" % e)
+        print("Exception when calling Liff->liff_v1_apps_liff_id_delete: %s\n" % e)
 ```
 
 
@@ -163,8 +163,8 @@ void (empty response body)
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **get_all_liff_apps**
-> GetAllLiffAppsResponse get_all_liff_apps()
+# **liff_v1_apps_get**
+> GetAllLiffAppsResponse liff_v1_apps_get()
 
 Get all LIFF apps
 
@@ -204,11 +204,11 @@ with linebot.v3.liff.ApiClient(configuration) as api_client:
 
     try:
         # Get all LIFF apps
-        api_response = api_instance.get_all_liff_apps()
-        print("The response of Liff->get_all_liff_apps:\n")
+        api_response = api_instance.liff_v1_apps_get()
+        print("The response of Liff->liff_v1_apps_get:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling Liff->get_all_liff_apps: %s\n" % e)
+        print("Exception when calling Liff->liff_v1_apps_get: %s\n" % e)
 ```
 
 
@@ -237,8 +237,8 @@ This endpoint does not need any parameter.
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **update_liff_app**
-> update_liff_app(liff_id, update_liff_app_request)
+# **liff_v1_apps_liff_id_put**
+> liff_v1_apps_liff_id_put(liff_id, update_liff_app_request)
 
 
 
@@ -279,9 +279,9 @@ with linebot.v3.liff.ApiClient(configuration) as api_client:
     update_liff_app_request = linebot.v3.liff.UpdateLiffAppRequest() # UpdateLiffAppRequest | 
 
     try:
-        api_instance.update_liff_app(liff_id, update_liff_app_request)
+        api_instance.liff_v1_apps_liff_id_put(liff_id, update_liff_app_request)
     except Exception as e:
-        print("Exception when calling Liff->update_liff_app: %s\n" % e)
+        print("Exception when calling Liff->liff_v1_apps_liff_id_put: %s\n" % e)
 ```
 
 

--- a/linebot/v3/liff/docs/Liff.md
+++ b/linebot/v3/liff/docs/Liff.md
@@ -4,241 +4,14 @@ All URIs are relative to *https://api.line.me*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**liff_v1_apps_get**](Liff.md#liff_v1_apps_get) | **GET** /liff/v1/apps | Get all LIFF apps
-[**liff_v1_apps_liff_id_delete**](Liff.md#liff_v1_apps_liff_id_delete) | **DELETE** /liff/v1/apps/{liffId} | Delete LIFF app from a channel
-[**liff_v1_apps_liff_id_put**](Liff.md#liff_v1_apps_liff_id_put) | **PUT** /liff/v1/apps/{liffId} | 
-[**liff_v1_apps_post**](Liff.md#liff_v1_apps_post) | **POST** /liff/v1/apps | 
+[**add_liff_app**](Liff.md#add_liff_app) | **POST** /liff/v1/apps | 
+[**delete_liff_app**](Liff.md#delete_liff_app) | **DELETE** /liff/v1/apps/{liffId} | Delete LIFF app from a channel
+[**get_all_liff_apps**](Liff.md#get_all_liff_apps) | **GET** /liff/v1/apps | Get all LIFF apps
+[**update_liff_app**](Liff.md#update_liff_app) | **PUT** /liff/v1/apps/{liffId} | 
 
 
-# **liff_v1_apps_get**
-> GetAllLiffAppsResponse liff_v1_apps_get()
-
-Get all LIFF apps
-
-Gets information on all the LIFF apps added to the channel.
-
-### Example
-
-* Bearer Authentication (Bearer):
-```python
-import time
-import os
-import linebot.v3.liff
-from linebot.v3.liff.models.get_all_liff_apps_response import GetAllLiffAppsResponse
-from linebot.v3.liff.rest import ApiException
-from pprint import pprint
-
-# Defining the host is optional and defaults to https://api.line.me
-# See configuration.py for a list of all supported configuration parameters.
-configuration = linebot.v3.liff.Configuration(
-    host = "https://api.line.me"
-)
-
-# The client must configure the authentication and authorization parameters
-# in accordance with the API server security policy.
-# Examples for each auth method are provided below, use the example that
-# satisfies your auth use case.
-
-# Configure Bearer authorization: Bearer
-configuration = linebot.v3.liff.Configuration(
-    access_token = os.environ["BEARER_TOKEN"]
-)
-
-# Enter a context with an instance of the API client
-with linebot.v3.liff.ApiClient(configuration) as api_client:
-    # Create an instance of the API class
-    api_instance = linebot.v3.liff.Liff(api_client)
-
-    try:
-        # Get all LIFF apps
-        api_response = api_instance.liff_v1_apps_get()
-        print("The response of Liff->liff_v1_apps_get:\n")
-        pprint(api_response)
-    except Exception as e:
-        print("Exception when calling Liff->liff_v1_apps_get: %s\n" % e)
-```
-
-
-### Parameters
-This endpoint does not need any parameter.
-
-### Return type
-
-[**GetAllLiffAppsResponse**](GetAllLiffAppsResponse.md)
-
-### Authorization
-
-[Bearer](../README.md#Bearer)
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
-### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-**200** | OK |  -  |
-**401** | Authentication failed.  |  -  |
-**404** | There is no LIFF app on the channel.     |  -  |
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **liff_v1_apps_liff_id_delete**
-> liff_v1_apps_liff_id_delete(liff_id)
-
-Delete LIFF app from a channel
-
-Deletes a LIFF app from a channel. 
-
-### Example
-
-* Bearer Authentication (Bearer):
-```python
-import time
-import os
-import linebot.v3.liff
-from linebot.v3.liff.rest import ApiException
-from pprint import pprint
-
-# Defining the host is optional and defaults to https://api.line.me
-# See configuration.py for a list of all supported configuration parameters.
-configuration = linebot.v3.liff.Configuration(
-    host = "https://api.line.me"
-)
-
-# The client must configure the authentication and authorization parameters
-# in accordance with the API server security policy.
-# Examples for each auth method are provided below, use the example that
-# satisfies your auth use case.
-
-# Configure Bearer authorization: Bearer
-configuration = linebot.v3.liff.Configuration(
-    access_token = os.environ["BEARER_TOKEN"]
-)
-
-# Enter a context with an instance of the API client
-with linebot.v3.liff.ApiClient(configuration) as api_client:
-    # Create an instance of the API class
-    api_instance = linebot.v3.liff.Liff(api_client)
-    liff_id = 'liff_id_example' # str | ID of the LIFF app to be updated
-
-    try:
-        # Delete LIFF app from a channel
-        api_instance.liff_v1_apps_liff_id_delete(liff_id)
-    except Exception as e:
-        print("Exception when calling Liff->liff_v1_apps_liff_id_delete: %s\n" % e)
-```
-
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **liff_id** | **str**| ID of the LIFF app to be updated | 
-
-### Return type
-
-void (empty response body)
-
-### Authorization
-
-[Bearer](../README.md#Bearer)
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: Not defined
-
-### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-**200** | OK |  -  |
-**401** | Authentication failed.  |  -  |
-**404** | This status code means one of the following: - The specified LIFF app does not exist. - The specified LIFF app has been added to another channel.   |  -  |
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **liff_v1_apps_liff_id_put**
-> liff_v1_apps_liff_id_put(liff_id, update_liff_app_request)
-
-
-
-Update LIFF app settings
-
-### Example
-
-* Bearer Authentication (Bearer):
-```python
-import time
-import os
-import linebot.v3.liff
-from linebot.v3.liff.models.update_liff_app_request import UpdateLiffAppRequest
-from linebot.v3.liff.rest import ApiException
-from pprint import pprint
-
-# Defining the host is optional and defaults to https://api.line.me
-# See configuration.py for a list of all supported configuration parameters.
-configuration = linebot.v3.liff.Configuration(
-    host = "https://api.line.me"
-)
-
-# The client must configure the authentication and authorization parameters
-# in accordance with the API server security policy.
-# Examples for each auth method are provided below, use the example that
-# satisfies your auth use case.
-
-# Configure Bearer authorization: Bearer
-configuration = linebot.v3.liff.Configuration(
-    access_token = os.environ["BEARER_TOKEN"]
-)
-
-# Enter a context with an instance of the API client
-with linebot.v3.liff.ApiClient(configuration) as api_client:
-    # Create an instance of the API class
-    api_instance = linebot.v3.liff.Liff(api_client)
-    liff_id = 'liff_id_example' # str | ID of the LIFF app to be updated
-    update_liff_app_request = linebot.v3.liff.UpdateLiffAppRequest() # UpdateLiffAppRequest | 
-
-    try:
-        api_instance.liff_v1_apps_liff_id_put(liff_id, update_liff_app_request)
-    except Exception as e:
-        print("Exception when calling Liff->liff_v1_apps_liff_id_put: %s\n" % e)
-```
-
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **liff_id** | **str**| ID of the LIFF app to be updated | 
- **update_liff_app_request** | [**UpdateLiffAppRequest**](UpdateLiffAppRequest.md)|  | 
-
-### Return type
-
-void (empty response body)
-
-### Authorization
-
-[Bearer](../README.md#Bearer)
-
-### HTTP request headers
-
- - **Content-Type**: application/json
- - **Accept**: Not defined
-
-### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-**200** | OK |  -  |
-**400** | The request contains an invalid value.  |  -  |
-**401** | Authentication failed.  |  -  |
-**404** | This status code means one of the following: - The specified LIFF app does not exist. - The specified LIFF app has been added to another channel.  |  -  |
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **liff_v1_apps_post**
-> AddLiffAppResponse liff_v1_apps_post(add_liff_app_request)
+# **add_liff_app**
+> AddLiffAppResponse add_liff_app(add_liff_app_request)
 
 
 
@@ -279,11 +52,11 @@ with linebot.v3.liff.ApiClient(configuration) as api_client:
     add_liff_app_request = linebot.v3.liff.AddLiffAppRequest() # AddLiffAppRequest | 
 
     try:
-        api_response = api_instance.liff_v1_apps_post(add_liff_app_request)
-        print("The response of Liff->liff_v1_apps_post:\n")
+        api_response = api_instance.add_liff_app(add_liff_app_request)
+        print("The response of Liff->add_liff_app:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling Liff->liff_v1_apps_post: %s\n" % e)
+        print("Exception when calling Liff->add_liff_app: %s\n" % e)
 ```
 
 
@@ -312,6 +85,233 @@ Name | Type | Description  | Notes
 **200** | OK |  -  |
 **400** | This status code means one of the following:  - The request contains an invalid value. - The maximum number of LIFF apps that can be added to the channel has been reached.  |  -  |
 **401** | Authentication failed.   |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **delete_liff_app**
+> delete_liff_app(liff_id)
+
+Delete LIFF app from a channel
+
+Deletes a LIFF app from a channel. 
+
+### Example
+
+* Bearer Authentication (Bearer):
+```python
+import time
+import os
+import linebot.v3.liff
+from linebot.v3.liff.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to https://api.line.me
+# See configuration.py for a list of all supported configuration parameters.
+configuration = linebot.v3.liff.Configuration(
+    host = "https://api.line.me"
+)
+
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure Bearer authorization: Bearer
+configuration = linebot.v3.liff.Configuration(
+    access_token = os.environ["BEARER_TOKEN"]
+)
+
+# Enter a context with an instance of the API client
+with linebot.v3.liff.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = linebot.v3.liff.Liff(api_client)
+    liff_id = 'liff_id_example' # str | ID of the LIFF app to be updated
+
+    try:
+        # Delete LIFF app from a channel
+        api_instance.delete_liff_app(liff_id)
+    except Exception as e:
+        print("Exception when calling Liff->delete_liff_app: %s\n" % e)
+```
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **liff_id** | **str**| ID of the LIFF app to be updated | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | OK |  -  |
+**401** | Authentication failed.  |  -  |
+**404** | This status code means one of the following: - The specified LIFF app does not exist. - The specified LIFF app has been added to another channel.   |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **get_all_liff_apps**
+> GetAllLiffAppsResponse get_all_liff_apps()
+
+Get all LIFF apps
+
+Gets information on all the LIFF apps added to the channel.
+
+### Example
+
+* Bearer Authentication (Bearer):
+```python
+import time
+import os
+import linebot.v3.liff
+from linebot.v3.liff.models.get_all_liff_apps_response import GetAllLiffAppsResponse
+from linebot.v3.liff.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to https://api.line.me
+# See configuration.py for a list of all supported configuration parameters.
+configuration = linebot.v3.liff.Configuration(
+    host = "https://api.line.me"
+)
+
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure Bearer authorization: Bearer
+configuration = linebot.v3.liff.Configuration(
+    access_token = os.environ["BEARER_TOKEN"]
+)
+
+# Enter a context with an instance of the API client
+with linebot.v3.liff.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = linebot.v3.liff.Liff(api_client)
+
+    try:
+        # Get all LIFF apps
+        api_response = api_instance.get_all_liff_apps()
+        print("The response of Liff->get_all_liff_apps:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling Liff->get_all_liff_apps: %s\n" % e)
+```
+
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**GetAllLiffAppsResponse**](GetAllLiffAppsResponse.md)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | OK |  -  |
+**401** | Authentication failed.  |  -  |
+**404** | There is no LIFF app on the channel.     |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **update_liff_app**
+> update_liff_app(liff_id, update_liff_app_request)
+
+
+
+Update LIFF app settings
+
+### Example
+
+* Bearer Authentication (Bearer):
+```python
+import time
+import os
+import linebot.v3.liff
+from linebot.v3.liff.models.update_liff_app_request import UpdateLiffAppRequest
+from linebot.v3.liff.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to https://api.line.me
+# See configuration.py for a list of all supported configuration parameters.
+configuration = linebot.v3.liff.Configuration(
+    host = "https://api.line.me"
+)
+
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure Bearer authorization: Bearer
+configuration = linebot.v3.liff.Configuration(
+    access_token = os.environ["BEARER_TOKEN"]
+)
+
+# Enter a context with an instance of the API client
+with linebot.v3.liff.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = linebot.v3.liff.Liff(api_client)
+    liff_id = 'liff_id_example' # str | ID of the LIFF app to be updated
+    update_liff_app_request = linebot.v3.liff.UpdateLiffAppRequest() # UpdateLiffAppRequest | 
+
+    try:
+        api_instance.update_liff_app(liff_id, update_liff_app_request)
+    except Exception as e:
+        print("Exception when calling Liff->update_liff_app: %s\n" % e)
+```
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **liff_id** | **str**| ID of the LIFF app to be updated | 
+ **update_liff_app_request** | [**UpdateLiffAppRequest**](UpdateLiffAppRequest.md)|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | OK |  -  |
+**400** | The request contains an invalid value.  |  -  |
+**401** | Authentication failed.  |  -  |
+**404** | This status code means one of the following: - The specified LIFF app does not exist. - The specified LIFF app has been added to another channel.  |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/linebot/v3/liff/docs/Liff.md
+++ b/linebot/v3/liff/docs/Liff.md
@@ -4,14 +4,14 @@ All URIs are relative to *https://api.line.me*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**liff_v1_apps_post**](Liff.md#liff_v1_apps_post) | **POST** /liff/v1/apps | 
-[**liff_v1_apps_liff_id_delete**](Liff.md#liff_v1_apps_liff_id_delete) | **DELETE** /liff/v1/apps/{liffId} | Delete LIFF app from a channel
-[**liff_v1_apps_get**](Liff.md#liff_v1_apps_get) | **GET** /liff/v1/apps | Get all LIFF apps
-[**liff_v1_apps_liff_id_put**](Liff.md#liff_v1_apps_liff_id_put) | **PUT** /liff/v1/apps/{liffId} | 
+[**add_liff_app**](Liff.md#add_liff_app) | **POST** /liff/v1/apps | 
+[**delete_liff_app**](Liff.md#delete_liff_app) | **DELETE** /liff/v1/apps/{liffId} | Delete LIFF app from a channel
+[**get_all_liff_apps**](Liff.md#get_all_liff_apps) | **GET** /liff/v1/apps | Get all LIFF apps
+[**update_liff_app**](Liff.md#update_liff_app) | **PUT** /liff/v1/apps/{liffId} | 
 
 
-# **liff_v1_apps_post**
-> AddLiffAppResponse liff_v1_apps_post(add_liff_app_request)
+# **add_liff_app**
+> AddLiffAppResponse add_liff_app(add_liff_app_request)
 
 
 
@@ -52,11 +52,11 @@ with linebot.v3.liff.ApiClient(configuration) as api_client:
     add_liff_app_request = linebot.v3.liff.AddLiffAppRequest() # AddLiffAppRequest | 
 
     try:
-        api_response = api_instance.liff_v1_apps_post(add_liff_app_request)
-        print("The response of Liff->liff_v1_apps_post:\n")
+        api_response = api_instance.add_liff_app(add_liff_app_request)
+        print("The response of Liff->add_liff_app:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling Liff->liff_v1_apps_post: %s\n" % e)
+        print("Exception when calling Liff->add_liff_app: %s\n" % e)
 ```
 
 
@@ -88,8 +88,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **liff_v1_apps_liff_id_delete**
-> liff_v1_apps_liff_id_delete(liff_id)
+# **delete_liff_app**
+> delete_liff_app(liff_id)
 
 Delete LIFF app from a channel
 
@@ -129,9 +129,9 @@ with linebot.v3.liff.ApiClient(configuration) as api_client:
 
     try:
         # Delete LIFF app from a channel
-        api_instance.liff_v1_apps_liff_id_delete(liff_id)
+        api_instance.delete_liff_app(liff_id)
     except Exception as e:
-        print("Exception when calling Liff->liff_v1_apps_liff_id_delete: %s\n" % e)
+        print("Exception when calling Liff->delete_liff_app: %s\n" % e)
 ```
 
 
@@ -163,8 +163,8 @@ void (empty response body)
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **liff_v1_apps_get**
-> GetAllLiffAppsResponse liff_v1_apps_get()
+# **get_all_liff_apps**
+> GetAllLiffAppsResponse get_all_liff_apps()
 
 Get all LIFF apps
 
@@ -204,11 +204,11 @@ with linebot.v3.liff.ApiClient(configuration) as api_client:
 
     try:
         # Get all LIFF apps
-        api_response = api_instance.liff_v1_apps_get()
-        print("The response of Liff->liff_v1_apps_get:\n")
+        api_response = api_instance.get_all_liff_apps()
+        print("The response of Liff->get_all_liff_apps:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling Liff->liff_v1_apps_get: %s\n" % e)
+        print("Exception when calling Liff->get_all_liff_apps: %s\n" % e)
 ```
 
 
@@ -237,8 +237,8 @@ This endpoint does not need any parameter.
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **liff_v1_apps_liff_id_put**
-> liff_v1_apps_liff_id_put(liff_id, update_liff_app_request)
+# **update_liff_app**
+> update_liff_app(liff_id, update_liff_app_request)
 
 
 
@@ -279,9 +279,9 @@ with linebot.v3.liff.ApiClient(configuration) as api_client:
     update_liff_app_request = linebot.v3.liff.UpdateLiffAppRequest() # UpdateLiffAppRequest | 
 
     try:
-        api_instance.liff_v1_apps_liff_id_put(liff_id, update_liff_app_request)
+        api_instance.update_liff_app(liff_id, update_liff_app_request)
     except Exception as e:
-        print("Exception when calling Liff->liff_v1_apps_liff_id_put: %s\n" % e)
+        print("Exception when calling Liff->update_liff_app: %s\n" % e)
 ```
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ sphinx>=2
 sphinx_rtd_theme
 pypandoc
 twine
-black==23.7.0
+black==23.3.0


### PR DESCRIPTION
`liff.yml` is changed in line-openapi, but we won't like to cause breaking change and update library version. The purpose of this pull request is keep old function names by calling new function. We'll remove this workaround in v4.

`+ this pull request reverts https://github.com/line/line-bot-sdk-python/pull/483 because CI fails after its merge...