### PR TITLE
Drop python 3.7's CI since it's EOL.

### DIFF
--- a/.github/workflows/auto-testing.yml
+++ b/.github/workflows/auto-testing.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: [ '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
3.7 was EOL at 2023-06-27.

https://devguide.python.org/versions/