### PR TITLE
update pydantic from v1 to v2.

### DIFF
--- a/generator/src/main/java/line/bot/generator/PythonNextgenCustomClientGenerator.java
+++ b/generator/src/main/java/line/bot/generator/PythonNextgenCustomClientGenerator.java
@@ -1055,7 +1055,7 @@ public class PythonNextgenCustomClientGenerator extends AbstractPythonCodegen im
         // need pydantic imports
         if (!pydanticImports.isEmpty()) {
             Map<String, String> item = new HashMap<>();
-            item.put("import", String.format(Locale.ROOT, "from pydantic import %s\n", StringUtils.join(pydanticImports, ", ")));
+            item.put("import", String.format(Locale.ROOT, "from pydantic.v1 import %s\n", StringUtils.join(pydanticImports, ", ")));
             newImports.add(item);
         }
 

--- a/generator/src/main/resources/python-nextgen-custom-client/api.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/api.mustache
@@ -5,7 +5,7 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated{{#asyncio}}
 from typing import overload, Optional, Union, Awaitable{{/asyncio}}
 

--- a/generator/src/main/resources/python-nextgen-custom-client/api_response.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/api_response.mustache
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/generator/src/main/resources/python-nextgen-custom-client/asyncio/async_api.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/asyncio/async_api.mustache
@@ -6,7 +6,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 

--- a/generator/src/main/resources/python-nextgen-custom-client/model_anyof.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/model_anyof.mustache
@@ -5,12 +5,12 @@ import pprint
 import re  # noqa: F401
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}
 from typing import Any, List
-from pydantic import StrictStr, Field
+from pydantic.v1 import StrictStr, Field
 
 {{#lambda.uppercase}}{{{classname}}}{{/lambda.uppercase}}_ANY_OF_SCHEMAS = [{{#anyOf}}"{{.}}"{{^-last}}, {{/-last}}{{/anyOf}}]
 

--- a/generator/src/main/resources/python-nextgen-custom-client/model_enum.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/model_enum.mustache
@@ -4,7 +4,7 @@ import re  # noqa: F401
 from aenum import Enum, no_arg
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 
 
 class {{classname}}({{vendorExtensions.x-py-enum-type}}, Enum):

--- a/generator/src/main/resources/python-nextgen-custom-client/model_generic.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/model_generic.mustache
@@ -10,7 +10,7 @@ import {{{modelPackage}}}
 
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}
@@ -147,7 +147,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{#isArray}}
         {{^items.isPrimitiveType}}
         {{^items.isEnumOrRef}}
-        # override the default output from pydantic by calling `to_dict()` of each item in {{{name}}} (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in {{{name}}} (list)
         _items = []
         if self.{{{name}}}:
             for _item in self.{{{name}}}:
@@ -160,7 +160,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{#isMap}}
         {{^items.isPrimitiveType}}
         {{^items.isEnumOrRef}}
-        # override the default output from pydantic by calling `to_dict()` of each value in {{{name}}} (dict)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each value in {{{name}}} (dict)
         _field_dict = {}
         if self.{{{name}}}:
             for _key in self.{{{name}}}:
@@ -174,7 +174,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{^isContainer}}
         {{^isPrimitiveType}}
         {{^isEnumOrRef}}
-        # override the default output from pydantic by calling `to_dict()` of {{{name}}}
+        # override the default output from pydantic.v1 by calling `to_dict()` of {{{name}}}
         if self.{{{name}}}:
             _dict['{{{baseName}}}'] = self.{{{name}}}.to_dict()
         {{/isEnumOrRef}}

--- a/generator/src/main/resources/python-nextgen-custom-client/model_oneof.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/model_oneof.mustache
@@ -5,12 +5,12 @@ import pprint
 import re  # noqa: F401
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
-{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+{{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic.v1 import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}
 from typing import Any, List
-from pydantic import StrictStr, Field
+from pydantic.v1 import StrictStr, Field
 
 {{#lambda.uppercase}}{{{classname}}}{{/lambda.uppercase}}_ONE_OF_SCHEMAS = [{{#oneOf}}"{{.}}"{{^-last}}, {{/-last}}{{/oneOf}}]
 

--- a/linebot/v3/audience/api/async_manage_audience.py
+++ b/linebot/v3/audience/api/async_manage_audience.py
@@ -16,11 +16,11 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
-from pydantic import Field, StrictBool, StrictInt, StrictStr, conint
+from pydantic.v1 import Field, StrictBool, StrictInt, StrictStr, conint
 
 from linebot.v3.audience.models.add_audience_to_audience_group_request import AddAudienceToAudienceGroupRequest
 from linebot.v3.audience.models.audience_group_create_route import AudienceGroupCreateRoute

--- a/linebot/v3/audience/api/async_manage_audience_blob.py
+++ b/linebot/v3/audience/api/async_manage_audience_blob.py
@@ -16,11 +16,11 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
-from pydantic import Field, StrictBool, StrictBytes, StrictInt, StrictStr, constr
+from pydantic.v1 import Field, StrictBool, StrictBytes, StrictInt, StrictStr, constr
 
 from typing import Optional, Union
 

--- a/linebot/v3/audience/api/manage_audience.py
+++ b/linebot/v3/audience/api/manage_audience.py
@@ -15,10 +15,10 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictBool, StrictInt, StrictStr, conint
+from pydantic.v1 import Field, StrictBool, StrictInt, StrictStr, conint
 
 from linebot.v3.audience.models.add_audience_to_audience_group_request import AddAudienceToAudienceGroupRequest
 from linebot.v3.audience.models.audience_group_create_route import AudienceGroupCreateRoute

--- a/linebot/v3/audience/api/manage_audience_blob.py
+++ b/linebot/v3/audience/api/manage_audience_blob.py
@@ -15,10 +15,10 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictBool, StrictBytes, StrictInt, StrictStr, constr
+from pydantic.v1 import Field, StrictBool, StrictBytes, StrictInt, StrictStr, constr
 
 from typing import Optional, Union
 

--- a/linebot/v3/audience/api_response.py
+++ b/linebot/v3/audience/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/linebot/v3/audience/models/add_audience_to_audience_group_request.py
+++ b/linebot/v3/audience/models/add_audience_to_audience_group_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conlist
 from linebot.v3.audience.models.audience import Audience
 
 class AddAudienceToAudienceGroupRequest(BaseModel):
@@ -57,7 +57,7 @@ class AddAudienceToAudienceGroupRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in audiences (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in audiences (list)
         _items = []
         if self.audiences:
             for _item in self.audiences:

--- a/linebot/v3/audience/models/audience.py
+++ b/linebot/v3/audience/models/audience.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class Audience(BaseModel):
     """

--- a/linebot/v3/audience/models/audience_group.py
+++ b/linebot/v3/audience/models/audience_group.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, StrictStr
 from linebot.v3.audience.models.audience_group_create_route import AudienceGroupCreateRoute
 from linebot.v3.audience.models.audience_group_failed_type import AudienceGroupFailedType
 from linebot.v3.audience.models.audience_group_permission import AudienceGroupPermission

--- a/linebot/v3/audience/models/audience_group_job.py
+++ b/linebot/v3/audience/models/audience_group_job.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 from linebot.v3.audience.models.audience_group_job_failed_type import AudienceGroupJobFailedType
 from linebot.v3.audience.models.audience_group_job_status import AudienceGroupJobStatus
 from linebot.v3.audience.models.audience_group_job_type import AudienceGroupJobType

--- a/linebot/v3/audience/models/create_audience_group_request.py
+++ b/linebot/v3/audience/models/create_audience_group_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist, constr
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist, constr
 from linebot.v3.audience.models.audience import Audience
 
 class CreateAudienceGroupRequest(BaseModel):
@@ -58,7 +58,7 @@ class CreateAudienceGroupRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in audiences (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in audiences (list)
         _items = []
         if self.audiences:
             for _item in self.audiences:

--- a/linebot/v3/audience/models/create_audience_group_response.py
+++ b/linebot/v3/audience/models/create_audience_group_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, validator
 from linebot.v3.audience.models.audience_group_type import AudienceGroupType
 
 class CreateAudienceGroupResponse(BaseModel):

--- a/linebot/v3/audience/models/create_click_based_audience_group_request.py
+++ b/linebot/v3/audience/models/create_click_based_audience_group_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, constr
+from pydantic.v1 import BaseModel, Field, StrictStr, constr
 
 class CreateClickBasedAudienceGroupRequest(BaseModel):
     """

--- a/linebot/v3/audience/models/create_click_based_audience_group_response.py
+++ b/linebot/v3/audience/models/create_click_based_audience_group_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, StrictStr, validator
 from linebot.v3.audience.models.audience_group_type import AudienceGroupType
 
 class CreateClickBasedAudienceGroupResponse(BaseModel):

--- a/linebot/v3/audience/models/create_imp_based_audience_group_request.py
+++ b/linebot/v3/audience/models/create_imp_based_audience_group_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, constr
+from pydantic.v1 import BaseModel, Field, StrictStr, constr
 
 class CreateImpBasedAudienceGroupRequest(BaseModel):
     """

--- a/linebot/v3/audience/models/create_imp_based_audience_group_response.py
+++ b/linebot/v3/audience/models/create_imp_based_audience_group_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 from linebot.v3.audience.models.audience_group_type import AudienceGroupType
 
 class CreateImpBasedAudienceGroupResponse(BaseModel):

--- a/linebot/v3/audience/models/error_detail.py
+++ b/linebot/v3/audience/models/error_detail.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ErrorDetail(BaseModel):
     """

--- a/linebot/v3/audience/models/error_response.py
+++ b/linebot/v3/audience/models/error_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.audience.models.error_detail import ErrorDetail
 
 class ErrorResponse(BaseModel):
@@ -56,7 +56,7 @@ class ErrorResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in details (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in details (list)
         _items = []
         if self.details:
             for _item in self.details:

--- a/linebot/v3/audience/models/get_audience_data_response.py
+++ b/linebot/v3/audience/models/get_audience_data_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.audience.models.audience_group import AudienceGroup
 from linebot.v3.audience.models.audience_group_job import AudienceGroupJob
 
@@ -57,10 +57,10 @@ class GetAudienceDataResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of audience_group
+        # override the default output from pydantic.v1 by calling `to_dict()` of audience_group
         if self.audience_group:
             _dict['audienceGroup'] = self.audience_group.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in jobs (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in jobs (list)
         _items = []
         if self.jobs:
             for _item in self.jobs:

--- a/linebot/v3/audience/models/get_audience_group_authority_level_response.py
+++ b/linebot/v3/audience/models/get_audience_group_authority_level_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from linebot.v3.audience.models.audience_group_authority_level import AudienceGroupAuthorityLevel
 
 class GetAudienceGroupAuthorityLevelResponse(BaseModel):

--- a/linebot/v3/audience/models/get_audience_groups_response.py
+++ b/linebot/v3/audience/models/get_audience_groups_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, StrictInt, conlist
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, conlist
 from linebot.v3.audience.models.audience_group import AudienceGroup
 
 class GetAudienceGroupsResponse(BaseModel):
@@ -60,7 +60,7 @@ class GetAudienceGroupsResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in audience_groups (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in audience_groups (list)
         _items = []
         if self.audience_groups:
             for _item in self.audience_groups:

--- a/linebot/v3/audience/models/update_audience_group_authority_level_request.py
+++ b/linebot/v3/audience/models/update_audience_group_authority_level_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from linebot.v3.audience.models.audience_group_authority_level import AudienceGroupAuthorityLevel
 
 class UpdateAudienceGroupAuthorityLevelRequest(BaseModel):

--- a/linebot/v3/audience/models/update_audience_group_description_request.py
+++ b/linebot/v3/audience/models/update_audience_group_description_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class UpdateAudienceGroupDescriptionRequest(BaseModel):
     """

--- a/linebot/v3/insight/api/async_insight.py
+++ b/linebot/v3/insight/api/async_insight.py
@@ -16,11 +16,11 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
-from pydantic import Field, constr, validator
+from pydantic.v1 import Field, constr, validator
 
 from typing import Optional
 

--- a/linebot/v3/insight/api/insight.py
+++ b/linebot/v3/insight/api/insight.py
@@ -15,10 +15,10 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, constr, validator
+from pydantic.v1 import Field, constr, validator
 
 from typing import Optional
 

--- a/linebot/v3/insight/api_response.py
+++ b/linebot/v3/insight/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/linebot/v3/insight/models/age_tile.py
+++ b/linebot/v3/insight/models/age_tile.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr, validator
 
 class AgeTile(BaseModel):
     """

--- a/linebot/v3/insight/models/app_type_tile.py
+++ b/linebot/v3/insight/models/app_type_tile.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr, validator
 
 class AppTypeTile(BaseModel):
     """

--- a/linebot/v3/insight/models/area_tile.py
+++ b/linebot/v3/insight/models/area_tile.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr
 
 class AreaTile(BaseModel):
     """

--- a/linebot/v3/insight/models/error_detail.py
+++ b/linebot/v3/insight/models/error_detail.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ErrorDetail(BaseModel):
     """

--- a/linebot/v3/insight/models/error_response.py
+++ b/linebot/v3/insight/models/error_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.insight.models.error_detail import ErrorDetail
 
 class ErrorResponse(BaseModel):
@@ -56,7 +56,7 @@ class ErrorResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in details (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in details (list)
         _items = []
         if self.details:
             for _item in self.details:

--- a/linebot/v3/insight/models/gender_tile.py
+++ b/linebot/v3/insight/models/gender_tile.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr, validator
 
 class GenderTile(BaseModel):
     """

--- a/linebot/v3/insight/models/get_friends_demographics_response.py
+++ b/linebot/v3/insight/models/get_friends_demographics_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, conlist
+from pydantic.v1 import BaseModel, Field, StrictBool, conlist
 from linebot.v3.insight.models.age_tile import AgeTile
 from linebot.v3.insight.models.app_type_tile import AppTypeTile
 from linebot.v3.insight.models.area_tile import AreaTile
@@ -64,35 +64,35 @@ class GetFriendsDemographicsResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in genders (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in genders (list)
         _items = []
         if self.genders:
             for _item in self.genders:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['genders'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in ages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in ages (list)
         _items = []
         if self.ages:
             for _item in self.ages:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['ages'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in areas (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in areas (list)
         _items = []
         if self.areas:
             for _item in self.areas:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['areas'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in app_types (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in app_types (list)
         _items = []
         if self.app_types:
             for _item in self.app_types:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['appTypes'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in subscription_periods (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in subscription_periods (list)
         _items = []
         if self.subscription_periods:
             for _item in self.subscription_periods:

--- a/linebot/v3/insight/models/get_message_event_response.py
+++ b/linebot/v3/insight/models/get_message_event_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.insight.models.get_message_event_response_click import GetMessageEventResponseClick
 from linebot.v3.insight.models.get_message_event_response_message import GetMessageEventResponseMessage
 from linebot.v3.insight.models.get_message_event_response_overview import GetMessageEventResponseOverview
@@ -59,17 +59,17 @@ class GetMessageEventResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of overview
+        # override the default output from pydantic.v1 by calling `to_dict()` of overview
         if self.overview:
             _dict['overview'] = self.overview.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['messages'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in clicks (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in clicks (list)
         _items = []
         if self.clicks:
             for _item in self.clicks:

--- a/linebot/v3/insight/models/get_message_event_response_click.py
+++ b/linebot/v3/insight/models/get_message_event_response_click.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class GetMessageEventResponseClick(BaseModel):
     """

--- a/linebot/v3/insight/models/get_message_event_response_message.py
+++ b/linebot/v3/insight/models/get_message_event_response_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 
 class GetMessageEventResponseMessage(BaseModel):
     """

--- a/linebot/v3/insight/models/get_message_event_response_overview.py
+++ b/linebot/v3/insight/models/get_message_event_response_overview.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class GetMessageEventResponseOverview(BaseModel):
     """

--- a/linebot/v3/insight/models/get_number_of_followers_response.py
+++ b/linebot/v3/insight/models/get_number_of_followers_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, validator
 
 class GetNumberOfFollowersResponse(BaseModel):
     """

--- a/linebot/v3/insight/models/get_number_of_message_deliveries_response.py
+++ b/linebot/v3/insight/models/get_number_of_message_deliveries_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, validator
 
 class GetNumberOfMessageDeliveriesResponse(BaseModel):
     """

--- a/linebot/v3/insight/models/get_statistics_per_unit_response.py
+++ b/linebot/v3/insight/models/get_statistics_per_unit_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.insight.models.get_statistics_per_unit_response_click import GetStatisticsPerUnitResponseClick
 from linebot.v3.insight.models.get_statistics_per_unit_response_message import GetStatisticsPerUnitResponseMessage
 from linebot.v3.insight.models.get_statistics_per_unit_response_overview import GetStatisticsPerUnitResponseOverview
@@ -59,17 +59,17 @@ class GetStatisticsPerUnitResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of overview
+        # override the default output from pydantic.v1 by calling `to_dict()` of overview
         if self.overview:
             _dict['overview'] = self.overview.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['messages'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in clicks (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in clicks (list)
         _items = []
         if self.clicks:
             for _item in self.clicks:

--- a/linebot/v3/insight/models/get_statistics_per_unit_response_click.py
+++ b/linebot/v3/insight/models/get_statistics_per_unit_response_click.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class GetStatisticsPerUnitResponseClick(BaseModel):
     """

--- a/linebot/v3/insight/models/get_statistics_per_unit_response_message.py
+++ b/linebot/v3/insight/models/get_statistics_per_unit_response_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 
 class GetStatisticsPerUnitResponseMessage(BaseModel):
     """

--- a/linebot/v3/insight/models/get_statistics_per_unit_response_overview.py
+++ b/linebot/v3/insight/models/get_statistics_per_unit_response_overview.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 
 class GetStatisticsPerUnitResponseOverview(BaseModel):
     """

--- a/linebot/v3/insight/models/subscription_period_tile.py
+++ b/linebot/v3/insight/models/subscription_period_tile.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr, validator
 
 class SubscriptionPeriodTile(BaseModel):
     """

--- a/linebot/v3/liff/api/async_liff.py
+++ b/linebot/v3/liff/api/async_liff.py
@@ -16,11 +16,11 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
-from pydantic import Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 
 from linebot.v3.liff.models.add_liff_app_request import AddLiffAppRequest
 from linebot.v3.liff.models.add_liff_app_response import AddLiffAppResponse

--- a/linebot/v3/liff/api/liff.py
+++ b/linebot/v3/liff/api/liff.py
@@ -15,10 +15,10 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 
 from linebot.v3.liff.models.add_liff_app_request import AddLiffAppRequest
 from linebot.v3.liff.models.add_liff_app_response import AddLiffAppResponse

--- a/linebot/v3/liff/api_response.py
+++ b/linebot/v3/liff/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/linebot/v3/liff/models/add_liff_app_request.py
+++ b/linebot/v3/liff/models/add_liff_app_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.liff.models.liff_bot_prompt import LiffBotPrompt
 from linebot.v3.liff.models.liff_features import LiffFeatures
 from linebot.v3.liff.models.liff_scope import LiffScope
@@ -63,10 +63,10 @@ class AddLiffAppRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of view
+        # override the default output from pydantic.v1 by calling `to_dict()` of view
         if self.view:
             _dict['view'] = self.view.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of features
+        # override the default output from pydantic.v1 by calling `to_dict()` of features
         if self.features:
             _dict['features'] = self.features.to_dict()
         return _dict

--- a/linebot/v3/liff/models/add_liff_app_response.py
+++ b/linebot/v3/liff/models/add_liff_app_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class AddLiffAppResponse(BaseModel):
     """

--- a/linebot/v3/liff/models/get_all_liff_apps_response.py
+++ b/linebot/v3/liff/models/get_all_liff_apps_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, conlist
+from pydantic.v1 import BaseModel, conlist
 from linebot.v3.liff.models.liff_app import LiffApp
 
 class GetAllLiffAppsResponse(BaseModel):
@@ -54,7 +54,7 @@ class GetAllLiffAppsResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in apps (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in apps (list)
         _items = []
         if self.apps:
             for _item in self.apps:

--- a/linebot/v3/liff/models/liff_app.py
+++ b/linebot/v3/liff/models/liff_app.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.liff.models.liff_bot_prompt import LiffBotPrompt
 from linebot.v3.liff.models.liff_features import LiffFeatures
 from linebot.v3.liff.models.liff_scope import LiffScope
@@ -63,10 +63,10 @@ class LiffApp(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of view
+        # override the default output from pydantic.v1 by calling `to_dict()` of view
         if self.view:
             _dict['view'] = self.view.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of features
+        # override the default output from pydantic.v1 by calling `to_dict()` of features
         if self.features:
             _dict['features'] = self.features.to_dict()
         return _dict

--- a/linebot/v3/liff/models/liff_features.py
+++ b/linebot/v3/liff/models/liff_features.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool
+from pydantic.v1 import BaseModel, Field, StrictBool
 
 class LiffFeatures(BaseModel):
     """

--- a/linebot/v3/liff/models/liff_view.py
+++ b/linebot/v3/liff/models/liff_view.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, validator
 
 class LiffView(BaseModel):
     """

--- a/linebot/v3/liff/models/update_liff_app_request.py
+++ b/linebot/v3/liff/models/update_liff_app_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.liff.models.liff_bot_prompt import LiffBotPrompt
 from linebot.v3.liff.models.liff_features import LiffFeatures
 from linebot.v3.liff.models.liff_scope import LiffScope
@@ -63,10 +63,10 @@ class UpdateLiffAppRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of view
+        # override the default output from pydantic.v1 by calling `to_dict()` of view
         if self.view:
             _dict['view'] = self.view.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of features
+        # override the default output from pydantic.v1 by calling `to_dict()` of features
         if self.features:
             _dict['features'] = self.features.to_dict()
         return _dict

--- a/linebot/v3/messaging/api/async_messaging_api.py
+++ b/linebot/v3/messaging/api/async_messaging_api.py
@@ -16,11 +16,11 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
-from pydantic import Field, StrictStr, conint, constr, validator
+from pydantic.v1 import Field, StrictStr, conint, constr, validator
 
 from typing import Optional
 

--- a/linebot/v3/messaging/api/async_messaging_api_blob.py
+++ b/linebot/v3/messaging/api/async_messaging_api_blob.py
@@ -16,11 +16,11 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
-from pydantic import Field, StrictBytes, StrictStr
+from pydantic.v1 import Field, StrictBytes, StrictStr
 
 from typing import Optional, Union
 

--- a/linebot/v3/messaging/api/messaging_api.py
+++ b/linebot/v3/messaging/api/messaging_api.py
@@ -15,10 +15,10 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, conint, constr, validator
+from pydantic.v1 import Field, StrictStr, conint, constr, validator
 
 from typing import Optional
 

--- a/linebot/v3/messaging/api/messaging_api_blob.py
+++ b/linebot/v3/messaging/api/messaging_api_blob.py
@@ -15,10 +15,10 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictBytes, StrictStr
+from pydantic.v1 import Field, StrictBytes, StrictStr
 
 from typing import Optional, Union
 

--- a/linebot/v3/messaging/api_response.py
+++ b/linebot/v3/messaging/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/linebot/v3/messaging/models/action.py
+++ b/linebot/v3/messaging/models/action.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class Action(BaseModel):
     """

--- a/linebot/v3/messaging/models/age_demographic_filter.py
+++ b/linebot/v3/messaging/models/age_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.messaging.models.age_demographic import AgeDemographic
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 

--- a/linebot/v3/messaging/models/alt_uri.py
+++ b/linebot/v3/messaging/models/alt_uri.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, constr
+from pydantic.v1 import BaseModel, constr
 
 class AltUri(BaseModel):
     """

--- a/linebot/v3/messaging/models/app_type_demographic_filter.py
+++ b/linebot/v3/messaging/models/app_type_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.messaging.models.app_type_demographic import AppTypeDemographic
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 

--- a/linebot/v3/messaging/models/area_demographic_filter.py
+++ b/linebot/v3/messaging/models/area_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.messaging.models.area_demographic import AreaDemographic
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 

--- a/linebot/v3/messaging/models/audience_match_messages_request.py
+++ b/linebot/v3/messaging/models/audience_match_messages_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist
 from linebot.v3.messaging.models.message import Message
 
 class AudienceMatchMessagesRequest(BaseModel):
@@ -57,7 +57,7 @@ class AudienceMatchMessagesRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:

--- a/linebot/v3/messaging/models/audience_recipient.py
+++ b/linebot/v3/messaging/models/audience_recipient.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 from linebot.v3.messaging.models.recipient import Recipient
 
 class AudienceRecipient(Recipient):

--- a/linebot/v3/messaging/models/audio_message.py
+++ b/linebot/v3/messaging/models/audio_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender
@@ -58,10 +58,10 @@ class AudioMessage(Message):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/bot_info_response.py
+++ b/linebot/v3/messaging/models/bot_info_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class BotInfoResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/broadcast_request.py
+++ b/linebot/v3/messaging/models/broadcast_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, conlist
+from pydantic.v1 import BaseModel, Field, StrictBool, conlist
 from linebot.v3.messaging.models.message import Message
 
 class BroadcastRequest(BaseModel):
@@ -56,7 +56,7 @@ class BroadcastRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:

--- a/linebot/v3/messaging/models/buttons_template.py
+++ b/linebot/v3/messaging/models/buttons_template.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.template import Template
 
@@ -63,10 +63,10 @@ class ButtonsTemplate(Template):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of default_action
+        # override the default output from pydantic.v1 by calling `to_dict()` of default_action
         if self.default_action:
             _dict['defaultAction'] = self.default_action.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in actions (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in actions (list)
         _items = []
         if self.actions:
             for _item in self.actions:

--- a/linebot/v3/messaging/models/camera_action.py
+++ b/linebot/v3/messaging/models/camera_action.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.messaging.models.action import Action
 
 class CameraAction(Action):

--- a/linebot/v3/messaging/models/camera_roll_action.py
+++ b/linebot/v3/messaging/models/camera_roll_action.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.messaging.models.action import Action
 
 class CameraRollAction(Action):

--- a/linebot/v3/messaging/models/carousel_column.py
+++ b/linebot/v3/messaging/models/carousel_column.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.messaging.models.action import Action
 
 class CarouselColumn(BaseModel):
@@ -59,10 +59,10 @@ class CarouselColumn(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of default_action
+        # override the default output from pydantic.v1 by calling `to_dict()` of default_action
         if self.default_action:
             _dict['defaultAction'] = self.default_action.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in actions (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in actions (list)
         _items = []
         if self.actions:
             for _item in self.actions:

--- a/linebot/v3/messaging/models/carousel_template.py
+++ b/linebot/v3/messaging/models/carousel_template.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.messaging.models.carousel_column import CarouselColumn
 from linebot.v3.messaging.models.template import Template
 
@@ -58,7 +58,7 @@ class CarouselTemplate(Template):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in columns (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in columns (list)
         _items = []
         if self.columns:
             for _item in self.columns:

--- a/linebot/v3/messaging/models/chat_reference.py
+++ b/linebot/v3/messaging/models/chat_reference.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ChatReference(BaseModel):
     """

--- a/linebot/v3/messaging/models/confirm_template.py
+++ b/linebot/v3/messaging/models/confirm_template.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, StrictStr, conlist
+from pydantic.v1 import BaseModel, StrictStr, conlist
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.template import Template
 
@@ -57,7 +57,7 @@ class ConfirmTemplate(Template):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in actions (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in actions (list)
         _items = []
         if self.actions:
             for _item in self.actions:

--- a/linebot/v3/messaging/models/create_rich_menu_alias_request.py
+++ b/linebot/v3/messaging/models/create_rich_menu_alias_request.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 
 class CreateRichMenuAliasRequest(BaseModel):
     """

--- a/linebot/v3/messaging/models/datetime_picker_action.py
+++ b/linebot/v3/messaging/models/datetime_picker_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, StrictStr, constr, validator
 from linebot.v3.messaging.models.action import Action
 
 class DatetimePickerAction(Action):

--- a/linebot/v3/messaging/models/demographic_filter.py
+++ b/linebot/v3/messaging/models/demographic_filter.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class DemographicFilter(BaseModel):
     """

--- a/linebot/v3/messaging/models/emoji.py
+++ b/linebot/v3/messaging/models/emoji.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class Emoji(BaseModel):
     """

--- a/linebot/v3/messaging/models/error_detail.py
+++ b/linebot/v3/messaging/models/error_detail.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ErrorDetail(BaseModel):
     """

--- a/linebot/v3/messaging/models/error_response.py
+++ b/linebot/v3/messaging/models/error_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.messaging.models.error_detail import ErrorDetail
 
 class ErrorResponse(BaseModel):
@@ -56,7 +56,7 @@ class ErrorResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in details (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in details (list)
         _items = []
         if self.details:
             for _item in self.details:

--- a/linebot/v3/messaging/models/filter.py
+++ b/linebot/v3/messaging/models/filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 
 class Filter(BaseModel):
@@ -54,7 +54,7 @@ class Filter(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of demographic
+        # override the default output from pydantic.v1 by calling `to_dict()` of demographic
         if self.demographic:
             _dict['demographic'] = self.demographic.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/flex_block_style.py
+++ b/linebot/v3/messaging/models/flex_block_style.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr
 
 class FlexBlockStyle(BaseModel):
     """

--- a/linebot/v3/messaging/models/flex_box.py
+++ b/linebot/v3/messaging/models/flex_box.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist, validator
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conlist, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_box_background import FlexBoxBackground
 from linebot.v3.messaging.models.flex_component import FlexComponent
@@ -123,17 +123,17 @@ class FlexBox(FlexComponent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in contents (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in contents (list)
         _items = []
         if self.contents:
             for _item in self.contents:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['contents'] = _items
-        # override the default output from pydantic by calling `to_dict()` of action
+        # override the default output from pydantic.v1 by calling `to_dict()` of action
         if self.action:
             _dict['action'] = self.action.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of background
+        # override the default output from pydantic.v1 by calling `to_dict()` of background
         if self.background:
             _dict['background'] = self.background.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/flex_box_background.py
+++ b/linebot/v3/messaging/models/flex_box_background.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class FlexBoxBackground(BaseModel):
     """

--- a/linebot/v3/messaging/models/flex_box_linear_gradient.py
+++ b/linebot/v3/messaging/models/flex_box_linear_gradient.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.flex_box_background import FlexBoxBackground
 
 class FlexBoxLinearGradient(FlexBoxBackground):

--- a/linebot/v3/messaging/models/flex_bubble.py
+++ b/linebot/v3/messaging/models/flex_bubble.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictStr, validator
+from pydantic.v1 import BaseModel, StrictStr, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_box import FlexBox
 from linebot.v3.messaging.models.flex_bubble_styles import FlexBubbleStyles
@@ -86,22 +86,22 @@ class FlexBubble(FlexContainer):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of styles
+        # override the default output from pydantic.v1 by calling `to_dict()` of styles
         if self.styles:
             _dict['styles'] = self.styles.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of header
+        # override the default output from pydantic.v1 by calling `to_dict()` of header
         if self.header:
             _dict['header'] = self.header.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of hero
+        # override the default output from pydantic.v1 by calling `to_dict()` of hero
         if self.hero:
             _dict['hero'] = self.hero.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of body
+        # override the default output from pydantic.v1 by calling `to_dict()` of body
         if self.body:
             _dict['body'] = self.body.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of footer
+        # override the default output from pydantic.v1 by calling `to_dict()` of footer
         if self.footer:
             _dict['footer'] = self.footer.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of action
+        # override the default output from pydantic.v1 by calling `to_dict()` of action
         if self.action:
             _dict['action'] = self.action.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/flex_bubble_styles.py
+++ b/linebot/v3/messaging/models/flex_bubble_styles.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.messaging.models.flex_block_style import FlexBlockStyle
 
 class FlexBubbleStyles(BaseModel):
@@ -57,16 +57,16 @@ class FlexBubbleStyles(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of header
+        # override the default output from pydantic.v1 by calling `to_dict()` of header
         if self.header:
             _dict['header'] = self.header.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of hero
+        # override the default output from pydantic.v1 by calling `to_dict()` of hero
         if self.hero:
             _dict['hero'] = self.hero.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of body
+        # override the default output from pydantic.v1 by calling `to_dict()` of body
         if self.body:
             _dict['body'] = self.body.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of footer
+        # override the default output from pydantic.v1 by calling `to_dict()` of footer
         if self.footer:
             _dict['footer'] = self.footer.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/flex_button.py
+++ b/linebot/v3/messaging/models/flex_button.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, StrictStr, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
@@ -119,7 +119,7 @@ class FlexButton(FlexComponent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of action
+        # override the default output from pydantic.v1 by calling `to_dict()` of action
         if self.action:
             _dict['action'] = self.action.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/flex_carousel.py
+++ b/linebot/v3/messaging/models/flex_carousel.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, conlist
+from pydantic.v1 import BaseModel, conlist
 from linebot.v3.messaging.models.flex_bubble import FlexBubble
 from linebot.v3.messaging.models.flex_container import FlexContainer
 
@@ -56,7 +56,7 @@ class FlexCarousel(FlexContainer):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in contents (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in contents (list)
         _items = []
         if self.contents:
             for _item in self.contents:

--- a/linebot/v3/messaging/models/flex_component.py
+++ b/linebot/v3/messaging/models/flex_component.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class FlexComponent(BaseModel):
     """

--- a/linebot/v3/messaging/models/flex_container.py
+++ b/linebot/v3/messaging/models/flex_container.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class FlexContainer(BaseModel):
     """

--- a/linebot/v3/messaging/models/flex_filler.py
+++ b/linebot/v3/messaging/models/flex_filler.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictInt
+from pydantic.v1 import BaseModel, StrictInt
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
 class FlexFiller(FlexComponent):

--- a/linebot/v3/messaging/models/flex_icon.py
+++ b/linebot/v3/messaging/models/flex_icon.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, validator
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
 class FlexIcon(FlexComponent):

--- a/linebot/v3/messaging/models/flex_image.py
+++ b/linebot/v3/messaging/models/flex_image.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, StrictStr, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
@@ -112,7 +112,7 @@ class FlexImage(FlexComponent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of action
+        # override the default output from pydantic.v1 by calling `to_dict()` of action
         if self.action:
             _dict['action'] = self.action.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/flex_message.py
+++ b/linebot/v3/messaging/models/flex_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.flex_container import FlexContainer
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
@@ -60,13 +60,13 @@ class FlexMessage(Message):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of contents
+        # override the default output from pydantic.v1 by calling `to_dict()` of contents
         if self.contents:
             _dict['contents'] = self.contents.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/flex_separator.py
+++ b/linebot/v3/messaging/models/flex_separator.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictStr
+from pydantic.v1 import BaseModel, StrictStr
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
 class FlexSeparator(FlexComponent):

--- a/linebot/v3/messaging/models/flex_span.py
+++ b/linebot/v3/messaging/models/flex_span.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictStr, validator
+from pydantic.v1 import BaseModel, StrictStr, validator
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
 class FlexSpan(FlexComponent):

--- a/linebot/v3/messaging/models/flex_text.py
+++ b/linebot/v3/messaging/models/flex_text.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, conlist, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, StrictStr, conlist, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_component import FlexComponent
 from linebot.v3.messaging.models.flex_span import FlexSpan
@@ -148,10 +148,10 @@ class FlexText(FlexComponent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of action
+        # override the default output from pydantic.v1 by calling `to_dict()` of action
         if self.action:
             _dict['action'] = self.action.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in contents (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in contents (list)
         _items = []
         if self.contents:
             for _item in self.contents:

--- a/linebot/v3/messaging/models/flex_video.py
+++ b/linebot/v3/messaging/models/flex_video.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
@@ -60,10 +60,10 @@ class FlexVideo(FlexComponent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of alt_content
+        # override the default output from pydantic.v1 by calling `to_dict()` of alt_content
         if self.alt_content:
             _dict['altContent'] = self.alt_content.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of action
+        # override the default output from pydantic.v1 by calling `to_dict()` of action
         if self.action:
             _dict['action'] = self.action.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/gender_demographic_filter.py
+++ b/linebot/v3/messaging/models/gender_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 from linebot.v3.messaging.models.gender_demographic import GenderDemographic
 

--- a/linebot/v3/messaging/models/get_aggregation_unit_name_list_response.py
+++ b/linebot/v3/messaging/models/get_aggregation_unit_name_list_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 
 class GetAggregationUnitNameListResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/get_aggregation_unit_usage_response.py
+++ b/linebot/v3/messaging/models/get_aggregation_unit_usage_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 
 class GetAggregationUnitUsageResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/get_followers_response.py
+++ b/linebot/v3/messaging/models/get_followers_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 
 class GetFollowersResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/get_message_content_transcoding_response.py
+++ b/linebot/v3/messaging/models/get_message_content_transcoding_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class GetMessageContentTranscodingResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/get_webhook_endpoint_response.py
+++ b/linebot/v3/messaging/models/get_webhook_endpoint_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictBool, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr
 
 class GetWebhookEndpointResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/group_member_count_response.py
+++ b/linebot/v3/messaging/models/group_member_count_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 
 class GroupMemberCountResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/group_summary_response.py
+++ b/linebot/v3/messaging/models/group_summary_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class GroupSummaryResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/group_user_profile_response.py
+++ b/linebot/v3/messaging/models/group_user_profile_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class GroupUserProfileResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/image_carousel_column.py
+++ b/linebot/v3/messaging/models/image_carousel_column.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.action import Action
 
 class ImageCarouselColumn(BaseModel):
@@ -55,7 +55,7 @@ class ImageCarouselColumn(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of action
+        # override the default output from pydantic.v1 by calling `to_dict()` of action
         if self.action:
             _dict['action'] = self.action.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/image_carousel_template.py
+++ b/linebot/v3/messaging/models/image_carousel_template.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, conlist
+from pydantic.v1 import BaseModel, conlist
 from linebot.v3.messaging.models.image_carousel_column import ImageCarouselColumn
 from linebot.v3.messaging.models.template import Template
 
@@ -56,7 +56,7 @@ class ImageCarouselTemplate(Template):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in columns (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in columns (list)
         _items = []
         if self.columns:
             for _item in self.columns:

--- a/linebot/v3/messaging/models/image_message.py
+++ b/linebot/v3/messaging/models/image_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender
@@ -58,10 +58,10 @@ class ImageMessage(Message):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/imagemap_action.py
+++ b/linebot/v3/messaging/models/imagemap_action.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.imagemap_area import ImagemapArea
 
 class ImagemapAction(BaseModel):
@@ -75,7 +75,7 @@ class ImagemapAction(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of area
+        # override the default output from pydantic.v1 by calling `to_dict()` of area
         if self.area:
             _dict['area'] = self.area.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/imagemap_area.py
+++ b/linebot/v3/messaging/models/imagemap_area.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictInt
+from pydantic.v1 import BaseModel, StrictInt
 
 class ImagemapArea(BaseModel):
     """

--- a/linebot/v3/messaging/models/imagemap_base_size.py
+++ b/linebot/v3/messaging/models/imagemap_base_size.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictInt
+from pydantic.v1 import BaseModel, StrictInt
 
 class ImagemapBaseSize(BaseModel):
     """

--- a/linebot/v3/messaging/models/imagemap_external_link.py
+++ b/linebot/v3/messaging/models/imagemap_external_link.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ImagemapExternalLink(BaseModel):
     """

--- a/linebot/v3/messaging/models/imagemap_message.py
+++ b/linebot/v3/messaging/models/imagemap_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.messaging.models.imagemap_action import ImagemapAction
 from linebot.v3.messaging.models.imagemap_base_size import ImagemapBaseSize
 from linebot.v3.messaging.models.imagemap_video import ImagemapVideo
@@ -65,23 +65,23 @@ class ImagemapMessage(Message):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of base_size
+        # override the default output from pydantic.v1 by calling `to_dict()` of base_size
         if self.base_size:
             _dict['baseSize'] = self.base_size.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in actions (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in actions (list)
         _items = []
         if self.actions:
             for _item in self.actions:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['actions'] = _items
-        # override the default output from pydantic by calling `to_dict()` of video
+        # override the default output from pydantic.v1 by calling `to_dict()` of video
         if self.video:
             _dict['video'] = self.video.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/imagemap_video.py
+++ b/linebot/v3/messaging/models/imagemap_video.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.imagemap_area import ImagemapArea
 from linebot.v3.messaging.models.imagemap_external_link import ImagemapExternalLink
 
@@ -58,10 +58,10 @@ class ImagemapVideo(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of area
+        # override the default output from pydantic.v1 by calling `to_dict()` of area
         if self.area:
             _dict['area'] = self.area.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of external_link
+        # override the default output from pydantic.v1 by calling `to_dict()` of external_link
         if self.external_link:
             _dict['externalLink'] = self.external_link.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/issue_link_token_response.py
+++ b/linebot/v3/messaging/models/issue_link_token_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class IssueLinkTokenResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/limit.py
+++ b/linebot/v3/messaging/models/limit.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, conint
+from pydantic.v1 import BaseModel, Field, StrictBool, conint
 
 class Limit(BaseModel):
     """

--- a/linebot/v3/messaging/models/location_action.py
+++ b/linebot/v3/messaging/models/location_action.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.messaging.models.action import Action
 
 class LocationAction(Action):

--- a/linebot/v3/messaging/models/location_message.py
+++ b/linebot/v3/messaging/models/location_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import BaseModel, StrictFloat, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, StrictFloat, StrictInt, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender
@@ -60,10 +60,10 @@ class LocationMessage(Message):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/mark_messages_as_read_request.py
+++ b/linebot/v3/messaging/models/mark_messages_as_read_request.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from linebot.v3.messaging.models.chat_reference import ChatReference
 
 class MarkMessagesAsReadRequest(BaseModel):
@@ -55,7 +55,7 @@ class MarkMessagesAsReadRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of chat
+        # override the default output from pydantic.v1 by calling `to_dict()` of chat
         if self.chat:
             _dict['chat'] = self.chat.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/members_ids_response.py
+++ b/linebot/v3/messaging/models/members_ids_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 
 class MembersIdsResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/message.py
+++ b/linebot/v3/messaging/models/message.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender
 
@@ -84,10 +84,10 @@ class Message(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/message_action.py
+++ b/linebot/v3/messaging/models/message_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictStr
+from pydantic.v1 import BaseModel, StrictStr
 from linebot.v3.messaging.models.action import Action
 
 class MessageAction(Action):

--- a/linebot/v3/messaging/models/message_imagemap_action.py
+++ b/linebot/v3/messaging/models/message_imagemap_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictStr
+from pydantic.v1 import BaseModel, StrictStr
 from linebot.v3.messaging.models.imagemap_action import ImagemapAction
 from linebot.v3.messaging.models.imagemap_area import ImagemapArea
 
@@ -57,7 +57,7 @@ class MessageImagemapAction(ImagemapAction):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of area
+        # override the default output from pydantic.v1 by calling `to_dict()` of area
         if self.area:
             _dict['area'] = self.area.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/message_quota_response.py
+++ b/linebot/v3/messaging/models/message_quota_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 from linebot.v3.messaging.models.quota_type import QuotaType
 
 class MessageQuotaResponse(BaseModel):

--- a/linebot/v3/messaging/models/multicast_request.py
+++ b/linebot/v3/messaging/models/multicast_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist, constr, validator
 from linebot.v3.messaging.models.message import Message
 
 class MulticastRequest(BaseModel):
@@ -58,7 +58,7 @@ class MulticastRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:

--- a/linebot/v3/messaging/models/narrowcast_progress_response.py
+++ b/linebot/v3/messaging/models/narrowcast_progress_response.py
@@ -19,7 +19,7 @@ import json
 
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, validator
 
 class NarrowcastProgressResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/narrowcast_request.py
+++ b/linebot/v3/messaging/models/narrowcast_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, conlist
+from pydantic.v1 import BaseModel, Field, StrictBool, conlist
 from linebot.v3.messaging.models.filter import Filter
 from linebot.v3.messaging.models.limit import Limit
 from linebot.v3.messaging.models.message import Message
@@ -62,20 +62,20 @@ class NarrowcastRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['messages'] = _items
-        # override the default output from pydantic by calling `to_dict()` of recipient
+        # override the default output from pydantic.v1 by calling `to_dict()` of recipient
         if self.recipient:
             _dict['recipient'] = self.recipient.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of filter
+        # override the default output from pydantic.v1 by calling `to_dict()` of filter
         if self.filter:
             _dict['filter'] = self.filter.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of limit
+        # override the default output from pydantic.v1 by calling `to_dict()` of limit
         if self.limit:
             _dict['limit'] = self.limit.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/number_of_messages_response.py
+++ b/linebot/v3/messaging/models/number_of_messages_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, validator
 
 class NumberOfMessagesResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/operator_demographic_filter.py
+++ b/linebot/v3/messaging/models/operator_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 
 class OperatorDemographicFilter(DemographicFilter):
@@ -57,21 +57,21 @@ class OperatorDemographicFilter(DemographicFilter):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in var_and (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in var_and (list)
         _items = []
         if self.var_and:
             for _item in self.var_and:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['and'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in var_or (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in var_or (list)
         _items = []
         if self.var_or:
             for _item in self.var_or:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['or'] = _items
-        # override the default output from pydantic by calling `to_dict()` of var_not
+        # override the default output from pydantic.v1 by calling `to_dict()` of var_not
         if self.var_not:
             _dict['not'] = self.var_not.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/operator_recipient.py
+++ b/linebot/v3/messaging/models/operator_recipient.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.messaging.models.recipient import Recipient
 
 class OperatorRecipient(Recipient):
@@ -57,21 +57,21 @@ class OperatorRecipient(Recipient):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in var_and (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in var_and (list)
         _items = []
         if self.var_and:
             for _item in self.var_and:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['and'] = _items
-        # override the default output from pydantic by calling `to_dict()` of each item in var_or (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in var_or (list)
         _items = []
         if self.var_or:
             for _item in self.var_or:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['or'] = _items
-        # override the default output from pydantic by calling `to_dict()` of var_not
+        # override the default output from pydantic.v1 by calling `to_dict()` of var_not
         if self.var_not:
             _dict['not'] = self.var_not.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/pnp_messages_request.py
+++ b/linebot/v3/messaging/models/pnp_messages_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist
 from linebot.v3.messaging.models.message import Message
 
 class PnpMessagesRequest(BaseModel):
@@ -57,7 +57,7 @@ class PnpMessagesRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:

--- a/linebot/v3/messaging/models/postback_action.py
+++ b/linebot/v3/messaging/models/postback_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
 from linebot.v3.messaging.models.action import Action
 
 class PostbackAction(Action):

--- a/linebot/v3/messaging/models/push_message_request.py
+++ b/linebot/v3/messaging/models/push_message_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist
 from linebot.v3.messaging.models.message import Message
 
 class PushMessageRequest(BaseModel):
@@ -58,7 +58,7 @@ class PushMessageRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:

--- a/linebot/v3/messaging/models/quick_reply.py
+++ b/linebot/v3/messaging/models/quick_reply.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.messaging.models.quick_reply_item import QuickReplyItem
 
 class QuickReply(BaseModel):
@@ -55,7 +55,7 @@ class QuickReply(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in items (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in items (list)
         _items = []
         if self.items:
             for _item in self.items:

--- a/linebot/v3/messaging/models/quick_reply_item.py
+++ b/linebot/v3/messaging/models/quick_reply_item.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, constr
+from pydantic.v1 import BaseModel, Field, StrictStr, constr
 from linebot.v3.messaging.models.action import Action
 
 class QuickReplyItem(BaseModel):
@@ -57,7 +57,7 @@ class QuickReplyItem(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of action
+        # override the default output from pydantic.v1 by calling `to_dict()` of action
         if self.action:
             _dict['action'] = self.action.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/quota_consumption_response.py
+++ b/linebot/v3/messaging/models/quota_consumption_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 
 class QuotaConsumptionResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/recipient.py
+++ b/linebot/v3/messaging/models/recipient.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class Recipient(BaseModel):
     """

--- a/linebot/v3/messaging/models/redelivery_recipient.py
+++ b/linebot/v3/messaging/models/redelivery_recipient.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.recipient import Recipient
 
 class RedeliveryRecipient(Recipient):

--- a/linebot/v3/messaging/models/reply_message_request.py
+++ b/linebot/v3/messaging/models/reply_message_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist
 from linebot.v3.messaging.models.message import Message
 
 class ReplyMessageRequest(BaseModel):
@@ -57,7 +57,7 @@ class ReplyMessageRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:

--- a/linebot/v3/messaging/models/rich_menu_alias_list_response.py
+++ b/linebot/v3/messaging/models/rich_menu_alias_list_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.messaging.models.rich_menu_alias_response import RichMenuAliasResponse
 
 class RichMenuAliasListResponse(BaseModel):
@@ -55,7 +55,7 @@ class RichMenuAliasListResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in aliases (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in aliases (list)
         _items = []
         if self.aliases:
             for _item in self.aliases:

--- a/linebot/v3/messaging/models/rich_menu_alias_response.py
+++ b/linebot/v3/messaging/models/rich_menu_alias_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class RichMenuAliasResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/rich_menu_area.py
+++ b/linebot/v3/messaging/models/rich_menu_area.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.rich_menu_bounds import RichMenuBounds
 
@@ -56,10 +56,10 @@ class RichMenuArea(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of bounds
+        # override the default output from pydantic.v1 by calling `to_dict()` of bounds
         if self.bounds:
             _dict['bounds'] = self.bounds.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of action
+        # override the default output from pydantic.v1 by calling `to_dict()` of action
         if self.action:
             _dict['action'] = self.action.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/rich_menu_batch_link_operation.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_link_operation.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.rich_menu_batch_operation import RichMenuBatchOperation
 
 class RichMenuBatchLinkOperation(RichMenuBatchOperation):

--- a/linebot/v3/messaging/models/rich_menu_batch_operation.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_operation.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class RichMenuBatchOperation(BaseModel):
     """

--- a/linebot/v3/messaging/models/rich_menu_batch_progress_response.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_progress_response.py
@@ -19,7 +19,7 @@ import json
 
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from linebot.v3.messaging.models.rich_menu_batch_progress_phase import RichMenuBatchProgressPhase
 
 class RichMenuBatchProgressResponse(BaseModel):

--- a/linebot/v3/messaging/models/rich_menu_batch_request.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, conlist, constr, validator
 from linebot.v3.messaging.models.rich_menu_batch_operation import RichMenuBatchOperation
 
 class RichMenuBatchRequest(BaseModel):
@@ -65,7 +65,7 @@ class RichMenuBatchRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in operations (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in operations (list)
         _items = []
         if self.operations:
             for _item in self.operations:

--- a/linebot/v3/messaging/models/rich_menu_batch_unlink_all_operation.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_unlink_all_operation.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.messaging.models.rich_menu_batch_operation import RichMenuBatchOperation
 
 class RichMenuBatchUnlinkAllOperation(RichMenuBatchOperation):

--- a/linebot/v3/messaging/models/rich_menu_batch_unlink_operation.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_unlink_operation.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.rich_menu_batch_operation import RichMenuBatchOperation
 
 class RichMenuBatchUnlinkOperation(RichMenuBatchOperation):

--- a/linebot/v3/messaging/models/rich_menu_bounds.py
+++ b/linebot/v3/messaging/models/rich_menu_bounds.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, conint
+from pydantic.v1 import BaseModel, Field, conint
 
 class RichMenuBounds(BaseModel):
     """

--- a/linebot/v3/messaging/models/rich_menu_bulk_link_request.py
+++ b/linebot/v3/messaging/models/rich_menu_bulk_link_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 
 class RichMenuBulkLinkRequest(BaseModel):
     """

--- a/linebot/v3/messaging/models/rich_menu_bulk_unlink_request.py
+++ b/linebot/v3/messaging/models/rich_menu_bulk_unlink_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 
 class RichMenuBulkUnlinkRequest(BaseModel):
     """

--- a/linebot/v3/messaging/models/rich_menu_id_response.py
+++ b/linebot/v3/messaging/models/rich_menu_id_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class RichMenuIdResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/rich_menu_list_response.py
+++ b/linebot/v3/messaging/models/rich_menu_list_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.messaging.models.rich_menu_response import RichMenuResponse
 
 class RichMenuListResponse(BaseModel):
@@ -55,7 +55,7 @@ class RichMenuListResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in richmenus (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in richmenus (list)
         _items = []
         if self.richmenus:
             for _item in self.richmenus:

--- a/linebot/v3/messaging/models/rich_menu_request.py
+++ b/linebot/v3/messaging/models/rich_menu_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictBool, conlist, constr
+from pydantic.v1 import BaseModel, Field, StrictBool, conlist, constr
 from linebot.v3.messaging.models.rich_menu_area import RichMenuArea
 from linebot.v3.messaging.models.rich_menu_size import RichMenuSize
 
@@ -59,10 +59,10 @@ class RichMenuRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of size
+        # override the default output from pydantic.v1 by calling `to_dict()` of size
         if self.size:
             _dict['size'] = self.size.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in areas (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in areas (list)
         _items = []
         if self.areas:
             for _item in self.areas:

--- a/linebot/v3/messaging/models/rich_menu_response.py
+++ b/linebot/v3/messaging/models/rich_menu_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist, constr
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist, constr
 from linebot.v3.messaging.models.rich_menu_area import RichMenuArea
 from linebot.v3.messaging.models.rich_menu_size import RichMenuSize
 
@@ -60,10 +60,10 @@ class RichMenuResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of size
+        # override the default output from pydantic.v1 by calling `to_dict()` of size
         if self.size:
             _dict['size'] = self.size.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in areas (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in areas (list)
         _items = []
         if self.areas:
             for _item in self.areas:

--- a/linebot/v3/messaging/models/rich_menu_size.py
+++ b/linebot/v3/messaging/models/rich_menu_size.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, conint
+from pydantic.v1 import BaseModel, Field, conint
 
 class RichMenuSize(BaseModel):
     """

--- a/linebot/v3/messaging/models/rich_menu_switch_action.py
+++ b/linebot/v3/messaging/models/rich_menu_switch_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 from linebot.v3.messaging.models.action import Action
 
 class RichMenuSwitchAction(Action):

--- a/linebot/v3/messaging/models/room_member_count_response.py
+++ b/linebot/v3/messaging/models/room_member_count_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 
 class RoomMemberCountResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/room_user_profile_response.py
+++ b/linebot/v3/messaging/models/room_user_profile_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class RoomUserProfileResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/sender.py
+++ b/linebot/v3/messaging/models/sender.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class Sender(BaseModel):
     """

--- a/linebot/v3/messaging/models/set_webhook_endpoint_request.py
+++ b/linebot/v3/messaging/models/set_webhook_endpoint_request.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class SetWebhookEndpointRequest(BaseModel):
     """

--- a/linebot/v3/messaging/models/sticker_message.py
+++ b/linebot/v3/messaging/models/sticker_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender
@@ -58,10 +58,10 @@ class StickerMessage(Message):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/subscription_period_demographic_filter.py
+++ b/linebot/v3/messaging/models/subscription_period_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 from linebot.v3.messaging.models.subscription_period_demographic import SubscriptionPeriodDemographic
 

--- a/linebot/v3/messaging/models/template.py
+++ b/linebot/v3/messaging/models/template.py
@@ -20,7 +20,7 @@ import linebot.v3.messaging.models
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class Template(BaseModel):
     """

--- a/linebot/v3/messaging/models/template_message.py
+++ b/linebot/v3/messaging/models/template_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender
@@ -59,13 +59,13 @@ class TemplateMessage(Message):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of template
+        # override the default output from pydantic.v1 by calling `to_dict()` of template
         if self.template:
             _dict['template'] = self.template.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/test_webhook_endpoint_request.py
+++ b/linebot/v3/messaging/models/test_webhook_endpoint_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr
 
 class TestWebhookEndpointRequest(BaseModel):
     """

--- a/linebot/v3/messaging/models/test_webhook_endpoint_response.py
+++ b/linebot/v3/messaging/models/test_webhook_endpoint_response.py
@@ -19,7 +19,7 @@ import json
 
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, StrictStr
 
 class TestWebhookEndpointResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/text_message.py
+++ b/linebot/v3/messaging/models/text_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, StrictStr, conlist
+from pydantic.v1 import BaseModel, StrictStr, conlist
 from linebot.v3.messaging.models.emoji import Emoji
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
@@ -59,13 +59,13 @@ class TextMessage(Message):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of each item in emojis (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in emojis (list)
         _items = []
         if self.emojis:
             for _item in self.emojis:

--- a/linebot/v3/messaging/models/update_rich_menu_alias_request.py
+++ b/linebot/v3/messaging/models/update_rich_menu_alias_request.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class UpdateRichMenuAliasRequest(BaseModel):
     """

--- a/linebot/v3/messaging/models/uri_action.py
+++ b/linebot/v3/messaging/models/uri_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.alt_uri import AltUri
 
@@ -57,7 +57,7 @@ class URIAction(Action):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of alt_uri
+        # override the default output from pydantic.v1 by calling `to_dict()` of alt_uri
         if self.alt_uri:
             _dict['altUri'] = self.alt_uri.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/uri_imagemap_action.py
+++ b/linebot/v3/messaging/models/uri_imagemap_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.imagemap_action import ImagemapAction
 from linebot.v3.messaging.models.imagemap_area import ImagemapArea
 
@@ -57,7 +57,7 @@ class URIImagemapAction(ImagemapAction):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of area
+        # override the default output from pydantic.v1 by calling `to_dict()` of area
         if self.area:
             _dict['area'] = self.area.to_dict()
         return _dict

--- a/linebot/v3/messaging/models/user_profile_response.py
+++ b/linebot/v3/messaging/models/user_profile_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class UserProfileResponse(BaseModel):
     """

--- a/linebot/v3/messaging/models/validate_message_request.py
+++ b/linebot/v3/messaging/models/validate_message_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.messaging.models.message import Message
 
 class ValidateMessageRequest(BaseModel):
@@ -54,7 +54,7 @@ class ValidateMessageRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in messages (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in messages (list)
         _items = []
         if self.messages:
             for _item in self.messages:

--- a/linebot/v3/messaging/models/video_message.py
+++ b/linebot/v3/messaging/models/video_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender
@@ -59,10 +59,10 @@ class VideoMessage(Message):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of quick_reply
+        # override the default output from pydantic.v1 by calling `to_dict()` of quick_reply
         if self.quick_reply:
             _dict['quickReply'] = self.quick_reply.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of sender
+        # override the default output from pydantic.v1 by calling `to_dict()` of sender
         if self.sender:
             _dict['sender'] = self.sender.to_dict()
         return _dict

--- a/linebot/v3/module/api/async_line_module.py
+++ b/linebot/v3/module/api/async_line_module.py
@@ -16,11 +16,11 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
-from pydantic import Field, StrictStr, conint
+from pydantic.v1 import Field, StrictStr, conint
 
 from typing import Optional
 

--- a/linebot/v3/module/api/line_module.py
+++ b/linebot/v3/module/api/line_module.py
@@ -15,10 +15,10 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr, conint
+from pydantic.v1 import Field, StrictStr, conint
 
 from typing import Optional
 

--- a/linebot/v3/module/api_response.py
+++ b/linebot/v3/module/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/linebot/v3/module/models/acquire_chat_control_request.py
+++ b/linebot/v3/module/models/acquire_chat_control_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictBool, conint
+from pydantic.v1 import BaseModel, Field, StrictBool, conint
 
 class AcquireChatControlRequest(BaseModel):
     """

--- a/linebot/v3/module/models/detach_module_request.py
+++ b/linebot/v3/module/models/detach_module_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class DetachModuleRequest(BaseModel):
     """

--- a/linebot/v3/module/models/get_modules_response.py
+++ b/linebot/v3/module/models/get_modules_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.module.models.module_bot import ModuleBot
 
 class GetModulesResponse(BaseModel):
@@ -56,7 +56,7 @@ class GetModulesResponse(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in bots (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in bots (list)
         _items = []
         if self.bots:
             for _item in self.bots:

--- a/linebot/v3/module/models/module_bot.py
+++ b/linebot/v3/module/models/module_bot.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ModuleBot(BaseModel):
     """

--- a/linebot/v3/moduleattach/api/async_line_module_attach.py
+++ b/linebot/v3/moduleattach/api/async_line_module_attach.py
@@ -16,11 +16,11 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
-from pydantic import Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 
 from typing import Optional
 

--- a/linebot/v3/moduleattach/api/line_module_attach.py
+++ b/linebot/v3/moduleattach/api/line_module_attach.py
@@ -15,10 +15,10 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 
 from typing import Optional
 

--- a/linebot/v3/moduleattach/api_response.py
+++ b/linebot/v3/moduleattach/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/linebot/v3/moduleattach/models/attach_module_response.py
+++ b/linebot/v3/moduleattach/models/attach_module_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 
 class AttachModuleResponse(BaseModel):
     """

--- a/linebot/v3/oauth/api/async_channel_access_token.py
+++ b/linebot/v3/oauth/api/async_channel_access_token.py
@@ -16,11 +16,11 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
-from pydantic import Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 
 from typing import Optional
 

--- a/linebot/v3/oauth/api/channel_access_token.py
+++ b/linebot/v3/oauth/api/channel_access_token.py
@@ -15,10 +15,10 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 
 from typing import Optional
 

--- a/linebot/v3/oauth/api_response.py
+++ b/linebot/v3/oauth/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/linebot/v3/oauth/models/channel_access_token_key_ids_response.py
+++ b/linebot/v3/oauth/models/channel_access_token_key_ids_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 
 class ChannelAccessTokenKeyIdsResponse(BaseModel):
     """

--- a/linebot/v3/oauth/models/error_response.py
+++ b/linebot/v3/oauth/models/error_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ErrorResponse(BaseModel):
     """

--- a/linebot/v3/oauth/models/issue_channel_access_token_response.py
+++ b/linebot/v3/oauth/models/issue_channel_access_token_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class IssueChannelAccessTokenResponse(BaseModel):
     """

--- a/linebot/v3/oauth/models/issue_short_lived_channel_access_token_response.py
+++ b/linebot/v3/oauth/models/issue_short_lived_channel_access_token_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class IssueShortLivedChannelAccessTokenResponse(BaseModel):
     """

--- a/linebot/v3/oauth/models/verify_channel_access_token_response.py
+++ b/linebot/v3/oauth/models/verify_channel_access_token_response.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class VerifyChannelAccessTokenResponse(BaseModel):
     """

--- a/linebot/v3/shop/api/async_shop.py
+++ b/linebot/v3/shop/api/async_shop.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 

--- a/linebot/v3/shop/api/shop.py
+++ b/linebot/v3/shop/api/shop.py
@@ -15,7 +15,7 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from linebot.v3.shop.models.mission_sticker_request import MissionStickerRequest

--- a/linebot/v3/shop/api_response.py
+++ b/linebot/v3/shop/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/linebot/v3/shop/models/error_response.py
+++ b/linebot/v3/shop/models/error_response.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ErrorResponse(BaseModel):
     """

--- a/linebot/v3/shop/models/mission_sticker_request.py
+++ b/linebot/v3/shop/models/mission_sticker_request.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictBool, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr
 
 class MissionStickerRequest(BaseModel):
     """

--- a/linebot/v3/webhooks/api/async_dummy.py
+++ b/linebot/v3/webhooks/api/async_dummy.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 

--- a/linebot/v3/webhooks/api/dummy.py
+++ b/linebot/v3/webhooks/api/dummy.py
@@ -15,7 +15,7 @@
 import re  # noqa: F401
 import io
 
-from pydantic import validate_arguments, ValidationError
+from pydantic.v1 import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from linebot.v3.webhooks.models.callback_request import CallbackRequest

--- a/linebot/v3/webhooks/api_response.py
+++ b/linebot/v3/webhooks/api_response.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/linebot/v3/webhooks/models/account_link_event.py
+++ b/linebot/v3/webhooks/models/account_link_event.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -60,13 +60,13 @@ class AccountLinkEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of link
+        # override the default output from pydantic.v1 by calling `to_dict()` of link
         if self.link:
             _dict['link'] = self.link.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/action_result.py
+++ b/linebot/v3/webhooks/models/action_result.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class ActionResult(BaseModel):
     """

--- a/linebot/v3/webhooks/models/activated_event.py
+++ b/linebot/v3/webhooks/models/activated_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from linebot.v3.webhooks.models.chat_control import ChatControl
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
@@ -59,13 +59,13 @@ class ActivatedEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of chat_control
+        # override the default output from pydantic.v1 by calling `to_dict()` of chat_control
         if self.chat_control:
             _dict['chatControl'] = self.chat_control.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/all_mentionee.py
+++ b/linebot/v3/webhooks/models/all_mentionee.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.webhooks.models.mentionee import Mentionee
 
 class AllMentionee(Mentionee):

--- a/linebot/v3/webhooks/models/attached_module_content.py
+++ b/linebot/v3/webhooks/models/attached_module_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.webhooks.models.module_content import ModuleContent
 
 class AttachedModuleContent(ModuleContent):

--- a/linebot/v3/webhooks/models/audio_message_content.py
+++ b/linebot/v3/webhooks/models/audio_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 from linebot.v3.webhooks.models.content_provider import ContentProvider
 from linebot.v3.webhooks.models.message_content import MessageContent
 
@@ -58,7 +58,7 @@ class AudioMessageContent(MessageContent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of content_provider
+        # override the default output from pydantic.v1 by calling `to_dict()` of content_provider
         if self.content_provider:
             _dict['contentProvider'] = self.content_provider.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/beacon_content.py
+++ b/linebot/v3/webhooks/models/beacon_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class BeaconContent(BaseModel):
     """

--- a/linebot/v3/webhooks/models/beacon_event.py
+++ b/linebot/v3/webhooks/models/beacon_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.beacon_content import BeaconContent
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
@@ -60,13 +60,13 @@ class BeaconEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of beacon
+        # override the default output from pydantic.v1 by calling `to_dict()` of beacon
         if self.beacon:
             _dict['beacon'] = self.beacon.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/bot_resumed_event.py
+++ b/linebot/v3/webhooks/models/bot_resumed_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -57,10 +57,10 @@ class BotResumedEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/bot_suspended_event.py
+++ b/linebot/v3/webhooks/models/bot_suspended_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -57,10 +57,10 @@ class BotSuspendedEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/callback_request.py
+++ b/linebot/v3/webhooks/models/callback_request.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, conlist, constr, validator
 from linebot.v3.webhooks.models.event import Event
 
 class CallbackRequest(BaseModel):
@@ -66,7 +66,7 @@ class CallbackRequest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in events (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in events (list)
         _items = []
         if self.events:
             for _item in self.events:

--- a/linebot/v3/webhooks/models/chat_control.py
+++ b/linebot/v3/webhooks/models/chat_control.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictInt
+from pydantic.v1 import BaseModel, Field, StrictInt
 
 class ChatControl(BaseModel):
     """

--- a/linebot/v3/webhooks/models/content_provider.py
+++ b/linebot/v3/webhooks/models/content_provider.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class ContentProvider(BaseModel):
     """

--- a/linebot/v3/webhooks/models/deactivated_event.py
+++ b/linebot/v3/webhooks/models/deactivated_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -57,10 +57,10 @@ class DeactivatedEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/delivery_context.py
+++ b/linebot/v3/webhooks/models/delivery_context.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictBool
+from pydantic.v1 import BaseModel, Field, StrictBool
 
 class DeliveryContext(BaseModel):
     """

--- a/linebot/v3/webhooks/models/detached_module_content.py
+++ b/linebot/v3/webhooks/models/detached_module_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 from linebot.v3.webhooks.models.module_content import ModuleContent
 
 class DetachedModuleContent(ModuleContent):

--- a/linebot/v3/webhooks/models/emoji.py
+++ b/linebot/v3/webhooks/models/emoji.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class Emoji(BaseModel):
     """

--- a/linebot/v3/webhooks/models/event.py
+++ b/linebot/v3/webhooks/models/event.py
@@ -20,7 +20,7 @@ import linebot.v3.webhooks.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event_mode import EventMode
 from linebot.v3.webhooks.models.source import Source
@@ -96,10 +96,10 @@ class Event(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/file_message_content.py
+++ b/linebot/v3/webhooks/models/file_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 from linebot.v3.webhooks.models.message_content import MessageContent
 
 class FileMessageContent(MessageContent):

--- a/linebot/v3/webhooks/models/follow_event.py
+++ b/linebot/v3/webhooks/models/follow_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -58,10 +58,10 @@ class FollowEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/group_source.py
+++ b/linebot/v3/webhooks/models/group_source.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.source import Source
 
 class GroupSource(Source):

--- a/linebot/v3/webhooks/models/image_message_content.py
+++ b/linebot/v3/webhooks/models/image_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.content_provider import ContentProvider
 from linebot.v3.webhooks.models.image_set import ImageSet
 from linebot.v3.webhooks.models.message_content import MessageContent
@@ -59,10 +59,10 @@ class ImageMessageContent(MessageContent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of content_provider
+        # override the default output from pydantic.v1 by calling `to_dict()` of content_provider
         if self.content_provider:
             _dict['contentProvider'] = self.content_provider.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of image_set
+        # override the default output from pydantic.v1 by calling `to_dict()` of image_set
         if self.image_set:
             _dict['imageSet'] = self.image_set.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/image_set.py
+++ b/linebot/v3/webhooks/models/image_set.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class ImageSet(BaseModel):
     """

--- a/linebot/v3/webhooks/models/join_event.py
+++ b/linebot/v3/webhooks/models/join_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -58,10 +58,10 @@ class JoinEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/joined_members.py
+++ b/linebot/v3/webhooks/models/joined_members.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.webhooks.models.user_source import UserSource
 
 class JoinedMembers(BaseModel):
@@ -54,7 +54,7 @@ class JoinedMembers(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in members (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in members (list)
         _items = []
         if self.members:
             for _item in self.members:

--- a/linebot/v3/webhooks/models/leave_event.py
+++ b/linebot/v3/webhooks/models/leave_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -57,10 +57,10 @@ class LeaveEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/left_members.py
+++ b/linebot/v3/webhooks/models/left_members.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.webhooks.models.user_source import UserSource
 
 class LeftMembers(BaseModel):
@@ -54,7 +54,7 @@ class LeftMembers(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in members (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in members (list)
         _items = []
         if self.members:
             for _item in self.members:

--- a/linebot/v3/webhooks/models/link_content.py
+++ b/linebot/v3/webhooks/models/link_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, validator
 
 class LinkContent(BaseModel):
     """

--- a/linebot/v3/webhooks/models/link_things_content.py
+++ b/linebot/v3/webhooks/models/link_things_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.things_content import ThingsContent
 
 class LinkThingsContent(ThingsContent):

--- a/linebot/v3/webhooks/models/location_message_content.py
+++ b/linebot/v3/webhooks/models/location_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr
 from linebot.v3.webhooks.models.message_content import MessageContent
 
 class LocationMessageContent(MessageContent):

--- a/linebot/v3/webhooks/models/member_joined_event.py
+++ b/linebot/v3/webhooks/models/member_joined_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -60,13 +60,13 @@ class MemberJoinedEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of joined
+        # override the default output from pydantic.v1 by calling `to_dict()` of joined
         if self.joined:
             _dict['joined'] = self.joined.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/member_left_event.py
+++ b/linebot/v3/webhooks/models/member_left_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -59,13 +59,13 @@ class MemberLeftEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of left
+        # override the default output from pydantic.v1 by calling `to_dict()` of left
         if self.left:
             _dict['left'] = self.left.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/mention.py
+++ b/linebot/v3/webhooks/models/mention.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic import BaseModel, Field, conlist
+from pydantic.v1 import BaseModel, Field, conlist
 from linebot.v3.webhooks.models.mentionee import Mentionee
 
 class Mention(BaseModel):
@@ -54,7 +54,7 @@ class Mention(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in mentionees (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in mentionees (list)
         _items = []
         if self.mentionees:
             for _item in self.mentionees:

--- a/linebot/v3/webhooks/models/mentionee.py
+++ b/linebot/v3/webhooks/models/mentionee.py
@@ -20,7 +20,7 @@ import linebot.v3.webhooks.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class Mentionee(BaseModel):
     """

--- a/linebot/v3/webhooks/models/message_content.py
+++ b/linebot/v3/webhooks/models/message_content.py
@@ -20,7 +20,7 @@ import linebot.v3.webhooks.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class MessageContent(BaseModel):
     """

--- a/linebot/v3/webhooks/models/message_event.py
+++ b/linebot/v3/webhooks/models/message_event.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -60,13 +60,13 @@ class MessageEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of message
+        # override the default output from pydantic.v1 by calling `to_dict()` of message
         if self.message:
             _dict['message'] = self.message.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/module_content.py
+++ b/linebot/v3/webhooks/models/module_content.py
@@ -20,7 +20,7 @@ import linebot.v3.webhooks.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ModuleContent(BaseModel):
     """

--- a/linebot/v3/webhooks/models/module_event.py
+++ b/linebot/v3/webhooks/models/module_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -59,13 +59,13 @@ class ModuleEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of module
+        # override the default output from pydantic.v1 by calling `to_dict()` of module
         if self.module:
             _dict['module'] = self.module.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/postback_content.py
+++ b/linebot/v3/webhooks/models/postback_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Dict, Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class PostbackContent(BaseModel):
     """

--- a/linebot/v3/webhooks/models/postback_event.py
+++ b/linebot/v3/webhooks/models/postback_event.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -60,13 +60,13 @@ class PostbackEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of postback
+        # override the default output from pydantic.v1 by calling `to_dict()` of postback
         if self.postback:
             _dict['postback'] = self.postback.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/room_source.py
+++ b/linebot/v3/webhooks/models/room_source.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.source import Source
 
 class RoomSource(Source):

--- a/linebot/v3/webhooks/models/scenario_result.py
+++ b/linebot/v3/webhooks/models/scenario_result.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conlist
 from linebot.v3.webhooks.models.action_result import ActionResult
 
 class ScenarioResult(BaseModel):
@@ -62,7 +62,7 @@ class ScenarioResult(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in action_results (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in action_results (list)
         _items = []
         if self.action_results:
             for _item in self.action_results:

--- a/linebot/v3/webhooks/models/scenario_result_things_content.py
+++ b/linebot/v3/webhooks/models/scenario_result_things_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.scenario_result import ScenarioResult
 from linebot.v3.webhooks.models.things_content import ThingsContent
 
@@ -57,7 +57,7 @@ class ScenarioResultThingsContent(ThingsContent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of result
+        # override the default output from pydantic.v1 by calling `to_dict()` of result
         if self.result:
             _dict['result'] = self.result.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/source.py
+++ b/linebot/v3/webhooks/models/source.py
@@ -20,7 +20,7 @@ import linebot.v3.webhooks.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class Source(BaseModel):
     """

--- a/linebot/v3/webhooks/models/sticker_message_content.py
+++ b/linebot/v3/webhooks/models/sticker_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist, constr, validator
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr, validator
 from linebot.v3.webhooks.models.message_content import MessageContent
 
 class StickerMessageContent(MessageContent):

--- a/linebot/v3/webhooks/models/text_message_content.py
+++ b/linebot/v3/webhooks/models/text_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import BaseModel, Field, StrictStr, conlist
 from linebot.v3.webhooks.models.emoji import Emoji
 from linebot.v3.webhooks.models.mention import Mention
 from linebot.v3.webhooks.models.message_content import MessageContent
@@ -60,14 +60,14 @@ class TextMessageContent(MessageContent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each item in emojis (list)
+        # override the default output from pydantic.v1 by calling `to_dict()` of each item in emojis (list)
         _items = []
         if self.emojis:
             for _item in self.emojis:
                 if _item:
                     _items.append(_item.to_dict())
             _dict['emojis'] = _items
-        # override the default output from pydantic by calling `to_dict()` of mention
+        # override the default output from pydantic.v1 by calling `to_dict()` of mention
         if self.mention:
             _dict['mention'] = self.mention.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/things_content.py
+++ b/linebot/v3/webhooks/models/things_content.py
@@ -20,7 +20,7 @@ import linebot.v3.webhooks.models
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ThingsContent(BaseModel):
     """

--- a/linebot/v3/webhooks/models/things_event.py
+++ b/linebot/v3/webhooks/models/things_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -60,13 +60,13 @@ class ThingsEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of things
+        # override the default output from pydantic.v1 by calling `to_dict()` of things
         if self.things:
             _dict['things'] = self.things.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/unfollow_event.py
+++ b/linebot/v3/webhooks/models/unfollow_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -57,10 +57,10 @@ class UnfollowEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/unlink_things_content.py
+++ b/linebot/v3/webhooks/models/unlink_things_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.things_content import ThingsContent
 
 class UnlinkThingsContent(ThingsContent):

--- a/linebot/v3/webhooks/models/unsend_detail.py
+++ b/linebot/v3/webhooks/models/unsend_detail.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class UnsendDetail(BaseModel):
     """

--- a/linebot/v3/webhooks/models/unsend_event.py
+++ b/linebot/v3/webhooks/models/unsend_event.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -59,13 +59,13 @@ class UnsendEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of unsend
+        # override the default output from pydantic.v1 by calling `to_dict()` of unsend
         if self.unsend:
             _dict['unsend'] = self.unsend.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/user_mentionee.py
+++ b/linebot/v3/webhooks/models/user_mentionee.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.mentionee import Mentionee
 
 class UserMentionee(Mentionee):

--- a/linebot/v3/webhooks/models/user_source.py
+++ b/linebot/v3/webhooks/models/user_source.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.source import Source
 
 class UserSource(Source):

--- a/linebot/v3/webhooks/models/video_message_content.py
+++ b/linebot/v3/webhooks/models/video_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 from linebot.v3.webhooks.models.content_provider import ContentProvider
 from linebot.v3.webhooks.models.message_content import MessageContent
 
@@ -58,7 +58,7 @@ class VideoMessageContent(MessageContent):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of content_provider
+        # override the default output from pydantic.v1 by calling `to_dict()` of content_provider
         if self.content_provider:
             _dict['contentProvider'] = self.content_provider.to_dict()
         return _dict

--- a/linebot/v3/webhooks/models/video_play_complete.py
+++ b/linebot/v3/webhooks/models/video_play_complete.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 
 class VideoPlayComplete(BaseModel):
     """

--- a/linebot/v3/webhooks/models/video_play_complete_event.py
+++ b/linebot/v3/webhooks/models/video_play_complete_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode
@@ -60,13 +60,13 @@ class VideoPlayCompleteEvent(Event):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of source
+        # override the default output from pydantic.v1 by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of delivery_context
+        # override the default output from pydantic.v1 by calling `to_dict()` of delivery_context
         if self.delivery_context:
             _dict['deliveryContext'] = self.delivery_context.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of video_play_complete
+        # override the default output from pydantic.v1 by calling `to_dict()` of video_play_complete
         if self.video_play_complete:
             _dict['videoPlayComplete'] = self.video_play_complete.to_dict()
         return _dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests ==2.31.0
 aiohttp ==3.8.5
 future
-pydantic >= 1.10.5, < 2
+pydantic >=2.0.3, <3
 aenum >= 3.1.11
 python_dateutil >= 2.5.3
 Deprecated


### PR DESCRIPTION
Ref #496

We should use the v2 native API... But at this time, just upgrade the library and use the compatibility layer.