### PR TITLE
Tweaks for openapi-generator v7

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -126,7 +126,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <openapi-generator-version>6.6.0</openapi-generator-version>
+        <openapi-generator-version>7.0.0</openapi-generator-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.2</junit-version>
     </properties>

--- a/generator/src/main/java/line/bot/generator/PythonNextgenCustomClientGenerator.java
+++ b/generator/src/main/java/line/bot/generator/PythonNextgenCustomClientGenerator.java
@@ -406,7 +406,7 @@ public class PythonNextgenCustomClientGenerator extends AbstractPythonCodegen im
             Schema inner = ap.getItems();
             return getSchemaType(p) + "[" + getTypeDeclaration(inner) + "]";
         } else if (ModelUtils.isMapSchema(p)) {
-            Schema inner = getAdditionalProperties(p);
+            Schema inner = ModelUtils.getAdditionalProperties(p);
 
             return getSchemaType(p) + "[str, " + getTypeDeclaration(inner) + "]";
         }
@@ -1549,7 +1549,7 @@ public class PythonNextgenCustomClientGenerator extends AbstractPythonCodegen im
 
     @Override
     protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Schema schema) {
-        final Schema additionalProperties = getAdditionalProperties(schema);
+        final Schema additionalProperties = ModelUtils.getAdditionalProperties(schema);
 
         if (additionalProperties != null) {
             codegenModel.additionalPropertiesType = getSchemaType(additionalProperties);

--- a/linebot/v3/audience/api/async_manage_audience.py
+++ b/linebot/v3/audience/api/async_manage_audience.py
@@ -1397,7 +1397,7 @@ class AsyncManageAudience(object):
             _query_params.append(('description', _params['description']))
 
         if _params.get('status') is not None:  # noqa: E501
-            _query_params.append(('status', _params['status']))
+            _query_params.append(('status', _params['status'].value))
 
         if _params.get('size') is not None:  # noqa: E501
             _query_params.append(('size', _params['size']))
@@ -1406,7 +1406,7 @@ class AsyncManageAudience(object):
             _query_params.append(('includesExternalPublicGroups', _params['includes_external_public_groups']))
 
         if _params.get('create_route') is not None:  # noqa: E501
-            _query_params.append(('createRoute', _params['create_route']))
+            _query_params.append(('createRoute', _params['create_route'].value))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))

--- a/linebot/v3/audience/api/manage_audience.py
+++ b/linebot/v3/audience/api/manage_audience.py
@@ -1305,7 +1305,7 @@ class ManageAudience(object):
             _query_params.append(('description', _params['description']))
 
         if _params.get('status') is not None:  # noqa: E501
-            _query_params.append(('status', _params['status']))
+            _query_params.append(('status', _params['status'].value))
 
         if _params.get('size') is not None:  # noqa: E501
             _query_params.append(('size', _params['size']))
@@ -1314,7 +1314,7 @@ class ManageAudience(object):
             _query_params.append(('includesExternalPublicGroups', _params['includes_external_public_groups']))
 
         if _params.get('create_route') is not None:  # noqa: E501
-            _query_params.append(('createRoute', _params['create_route']))
+            _query_params.append(('createRoute', _params['create_route'].value))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))

--- a/linebot/v3/messaging/models/action.py
+++ b/linebot/v3/messaging/models/action.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class Action(BaseModel):

--- a/linebot/v3/messaging/models/age_demographic_filter.py
+++ b/linebot/v3/messaging/models/age_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel
+
 from linebot.v3.messaging.models.age_demographic import AgeDemographic
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 

--- a/linebot/v3/messaging/models/app_type_demographic_filter.py
+++ b/linebot/v3/messaging/models/app_type_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, conlist
+from pydantic.v1 import Field, conlist
 from linebot.v3.messaging.models.app_type_demographic import AppTypeDemographic
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 

--- a/linebot/v3/messaging/models/area_demographic_filter.py
+++ b/linebot/v3/messaging/models/area_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, conlist
+from pydantic.v1 import Field, conlist
 from linebot.v3.messaging.models.area_demographic import AreaDemographic
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 

--- a/linebot/v3/messaging/models/audience_recipient.py
+++ b/linebot/v3/messaging/models/audience_recipient.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictInt
+from pydantic.v1 import Field, StrictInt
 from linebot.v3.messaging.models.recipient import Recipient
 
 class AudienceRecipient(Recipient):

--- a/linebot/v3/messaging/models/audio_message.py
+++ b/linebot/v3/messaging/models/audio_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender

--- a/linebot/v3/messaging/models/buttons_template.py
+++ b/linebot/v3/messaging/models/buttons_template.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import Field, StrictStr, conlist
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.template import Template
 

--- a/linebot/v3/messaging/models/camera_action.py
+++ b/linebot/v3/messaging/models/camera_action.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.messaging.models.action import Action
 
 class CameraAction(Action):

--- a/linebot/v3/messaging/models/camera_roll_action.py
+++ b/linebot/v3/messaging/models/camera_roll_action.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.messaging.models.action import Action
 
 class CameraRollAction(Action):

--- a/linebot/v3/messaging/models/carousel_template.py
+++ b/linebot/v3/messaging/models/carousel_template.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import Field, StrictStr, conlist
 from linebot.v3.messaging.models.carousel_column import CarouselColumn
 from linebot.v3.messaging.models.template import Template
 

--- a/linebot/v3/messaging/models/confirm_template.py
+++ b/linebot/v3/messaging/models/confirm_template.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, StrictStr, conlist
+from pydantic.v1 import StrictStr, conlist
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.template import Template
 

--- a/linebot/v3/messaging/models/datetime_picker_action.py
+++ b/linebot/v3/messaging/models/datetime_picker_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, StrictStr, constr, validator
+from pydantic.v1 import StrictStr, constr, validator
 from linebot.v3.messaging.models.action import Action
 
 class DatetimePickerAction(Action):

--- a/linebot/v3/messaging/models/demographic_filter.py
+++ b/linebot/v3/messaging/models/demographic_filter.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class DemographicFilter(BaseModel):

--- a/linebot/v3/messaging/models/flex_box.py
+++ b/linebot/v3/messaging/models/flex_box.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conlist, validator
+from pydantic.v1 import Field, StrictInt, StrictStr, conlist, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_box_background import FlexBoxBackground
 from linebot.v3.messaging.models.flex_component import FlexComponent

--- a/linebot/v3/messaging/models/flex_box_background.py
+++ b/linebot/v3/messaging/models/flex_box_background.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-
+from typing import Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class FlexBoxBackground(BaseModel):

--- a/linebot/v3/messaging/models/flex_box_linear_gradient.py
+++ b/linebot/v3/messaging/models/flex_box_linear_gradient.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.flex_box_background import FlexBoxBackground
 
 class FlexBoxLinearGradient(FlexBoxBackground):

--- a/linebot/v3/messaging/models/flex_bubble.py
+++ b/linebot/v3/messaging/models/flex_bubble.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, StrictStr, validator
+from pydantic.v1 import StrictStr, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_box import FlexBox
 from linebot.v3.messaging.models.flex_bubble_styles import FlexBubbleStyles

--- a/linebot/v3/messaging/models/flex_button.py
+++ b/linebot/v3/messaging/models/flex_button.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, StrictStr, validator
+from pydantic.v1 import Field, StrictBool, StrictInt, StrictStr, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_component import FlexComponent
 

--- a/linebot/v3/messaging/models/flex_carousel.py
+++ b/linebot/v3/messaging/models/flex_carousel.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, conlist
+from pydantic.v1 import conlist
 from linebot.v3.messaging.models.flex_bubble import FlexBubble
 from linebot.v3.messaging.models.flex_container import FlexContainer
 

--- a/linebot/v3/messaging/models/flex_component.py
+++ b/linebot/v3/messaging/models/flex_component.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-
+from typing import Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class FlexComponent(BaseModel):

--- a/linebot/v3/messaging/models/flex_container.py
+++ b/linebot/v3/messaging/models/flex_container.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-
+from typing import Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class FlexContainer(BaseModel):

--- a/linebot/v3/messaging/models/flex_filler.py
+++ b/linebot/v3/messaging/models/flex_filler.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, StrictInt
+from pydantic.v1 import StrictInt
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
 class FlexFiller(FlexComponent):

--- a/linebot/v3/messaging/models/flex_icon.py
+++ b/linebot/v3/messaging/models/flex_icon.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, validator
+from pydantic.v1 import Field, StrictBool, StrictStr, validator
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
 class FlexIcon(FlexComponent):

--- a/linebot/v3/messaging/models/flex_image.py
+++ b/linebot/v3/messaging/models/flex_image.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, StrictStr, validator
+from pydantic.v1 import Field, StrictBool, StrictInt, StrictStr, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_component import FlexComponent
 

--- a/linebot/v3/messaging/models/flex_message.py
+++ b/linebot/v3/messaging/models/flex_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.flex_container import FlexContainer
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply

--- a/linebot/v3/messaging/models/flex_separator.py
+++ b/linebot/v3/messaging/models/flex_separator.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, StrictStr
+from pydantic.v1 import StrictStr
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
 class FlexSeparator(FlexComponent):

--- a/linebot/v3/messaging/models/flex_span.py
+++ b/linebot/v3/messaging/models/flex_span.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, StrictStr, validator
+from pydantic.v1 import StrictStr, validator
 from linebot.v3.messaging.models.flex_component import FlexComponent
 
 class FlexSpan(FlexComponent):

--- a/linebot/v3/messaging/models/flex_text.py
+++ b/linebot/v3/messaging/models/flex_text.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt, StrictStr, conlist, validator
+from pydantic.v1 import Field, StrictBool, StrictInt, StrictStr, conlist, validator
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_component import FlexComponent
 from linebot.v3.messaging.models.flex_span import FlexSpan

--- a/linebot/v3/messaging/models/flex_video.py
+++ b/linebot/v3/messaging/models/flex_video.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.flex_component import FlexComponent
 

--- a/linebot/v3/messaging/models/gender_demographic_filter.py
+++ b/linebot/v3/messaging/models/gender_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, conlist
+from pydantic.v1 import Field, conlist
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 from linebot.v3.messaging.models.gender_demographic import GenderDemographic
 

--- a/linebot/v3/messaging/models/image_carousel_template.py
+++ b/linebot/v3/messaging/models/image_carousel_template.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, conlist
+from pydantic.v1 import conlist
 from linebot.v3.messaging.models.image_carousel_column import ImageCarouselColumn
 from linebot.v3.messaging.models.template import Template
 

--- a/linebot/v3/messaging/models/image_message.py
+++ b/linebot/v3/messaging/models/image_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender

--- a/linebot/v3/messaging/models/imagemap_action.py
+++ b/linebot/v3/messaging/models/imagemap_action.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.imagemap_area import ImagemapArea
 

--- a/linebot/v3/messaging/models/imagemap_message.py
+++ b/linebot/v3/messaging/models/imagemap_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import Field, StrictStr, conlist
 from linebot.v3.messaging.models.imagemap_action import ImagemapAction
 from linebot.v3.messaging.models.imagemap_base_size import ImagemapBaseSize
 from linebot.v3.messaging.models.imagemap_video import ImagemapVideo

--- a/linebot/v3/messaging/models/location_action.py
+++ b/linebot/v3/messaging/models/location_action.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.messaging.models.action import Action
 
 class LocationAction(Action):

--- a/linebot/v3/messaging/models/location_message.py
+++ b/linebot/v3/messaging/models/location_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic.v1 import BaseModel, StrictFloat, StrictInt, StrictStr
+from pydantic.v1 import StrictFloat, StrictInt, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender

--- a/linebot/v3/messaging/models/message.py
+++ b/linebot/v3/messaging/models/message.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender

--- a/linebot/v3/messaging/models/message_action.py
+++ b/linebot/v3/messaging/models/message_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, StrictStr
+from pydantic.v1 import StrictStr
 from linebot.v3.messaging.models.action import Action
 
 class MessageAction(Action):

--- a/linebot/v3/messaging/models/message_imagemap_action.py
+++ b/linebot/v3/messaging/models/message_imagemap_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, StrictStr
+from pydantic.v1 import StrictStr
 from linebot.v3.messaging.models.imagemap_action import ImagemapAction
 from linebot.v3.messaging.models.imagemap_area import ImagemapArea
 

--- a/linebot/v3/messaging/models/operator_demographic_filter.py
+++ b/linebot/v3/messaging/models/operator_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, conlist
+from pydantic.v1 import Field, conlist
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 
 class OperatorDemographicFilter(DemographicFilter):

--- a/linebot/v3/messaging/models/operator_recipient.py
+++ b/linebot/v3/messaging/models/operator_recipient.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, conlist
+from pydantic.v1 import Field, conlist
 from linebot.v3.messaging.models.recipient import Recipient
 
 class OperatorRecipient(Recipient):

--- a/linebot/v3/messaging/models/postback_action.py
+++ b/linebot/v3/messaging/models/postback_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+from pydantic.v1 import Field, StrictStr, constr, validator
 from linebot.v3.messaging.models.action import Action
 
 class PostbackAction(Action):

--- a/linebot/v3/messaging/models/recipient.py
+++ b/linebot/v3/messaging/models/recipient.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class Recipient(BaseModel):

--- a/linebot/v3/messaging/models/redelivery_recipient.py
+++ b/linebot/v3/messaging/models/redelivery_recipient.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.recipient import Recipient
 
 class RedeliveryRecipient(Recipient):

--- a/linebot/v3/messaging/models/rich_menu_batch_link_operation.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_link_operation.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.rich_menu_batch_operation import RichMenuBatchOperation
 
 class RichMenuBatchLinkOperation(RichMenuBatchOperation):

--- a/linebot/v3/messaging/models/rich_menu_batch_operation.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_operation.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-
+from typing import Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class RichMenuBatchOperation(BaseModel):

--- a/linebot/v3/messaging/models/rich_menu_batch_unlink_all_operation.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_unlink_all_operation.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.messaging.models.rich_menu_batch_operation import RichMenuBatchOperation
 
 class RichMenuBatchUnlinkAllOperation(RichMenuBatchOperation):

--- a/linebot/v3/messaging/models/rich_menu_batch_unlink_operation.py
+++ b/linebot/v3/messaging/models/rich_menu_batch_unlink_operation.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.rich_menu_batch_operation import RichMenuBatchOperation
 
 class RichMenuBatchUnlinkOperation(RichMenuBatchOperation):

--- a/linebot/v3/messaging/models/rich_menu_switch_action.py
+++ b/linebot/v3/messaging/models/rich_menu_switch_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, constr
+from pydantic.v1 import Field, constr
 from linebot.v3.messaging.models.action import Action
 
 class RichMenuSwitchAction(Action):

--- a/linebot/v3/messaging/models/sticker_message.py
+++ b/linebot/v3/messaging/models/sticker_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender

--- a/linebot/v3/messaging/models/subscription_period_demographic_filter.py
+++ b/linebot/v3/messaging/models/subscription_period_demographic_filter.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel
+
 from linebot.v3.messaging.models.demographic_filter import DemographicFilter
 from linebot.v3.messaging.models.subscription_period_demographic import SubscriptionPeriodDemographic
 

--- a/linebot/v3/messaging/models/template.py
+++ b/linebot/v3/messaging/models/template.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.messaging.models
 
 
-
+from typing import Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class Template(BaseModel):

--- a/linebot/v3/messaging/models/template_message.py
+++ b/linebot/v3/messaging/models/template_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender

--- a/linebot/v3/messaging/models/text_message.py
+++ b/linebot/v3/messaging/models/text_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, StrictStr, conlist
+from pydantic.v1 import StrictStr, conlist
 from linebot.v3.messaging.models.emoji import Emoji
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply

--- a/linebot/v3/messaging/models/uri_action.py
+++ b/linebot/v3/messaging/models/uri_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.action import Action
 from linebot.v3.messaging.models.alt_uri import AltUri
 

--- a/linebot/v3/messaging/models/uri_imagemap_action.py
+++ b/linebot/v3/messaging/models/uri_imagemap_action.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.imagemap_action import ImagemapAction
 from linebot.v3.messaging.models.imagemap_area import ImagemapArea
 

--- a/linebot/v3/messaging/models/video_message.py
+++ b/linebot/v3/messaging/models/video_message.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender

--- a/linebot/v3/webhooks/models/account_link_event.py
+++ b/linebot/v3/webhooks/models/account_link_event.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/activated_event.py
+++ b/linebot/v3/webhooks/models/activated_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field
+from pydantic.v1 import Field
 from linebot.v3.webhooks.models.chat_control import ChatControl
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event

--- a/linebot/v3/webhooks/models/all_mentionee.py
+++ b/linebot/v3/webhooks/models/all_mentionee.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.webhooks.models.mentionee import Mentionee
 
 class AllMentionee(Mentionee):

--- a/linebot/v3/webhooks/models/attached_module_content.py
+++ b/linebot/v3/webhooks/models/attached_module_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List
-from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import Field, StrictStr, conlist
 from linebot.v3.webhooks.models.module_content import ModuleContent
 
 class AttachedModuleContent(ModuleContent):

--- a/linebot/v3/webhooks/models/audio_message_content.py
+++ b/linebot/v3/webhooks/models/audio_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 from linebot.v3.webhooks.models.content_provider import ContentProvider
 from linebot.v3.webhooks.models.message_content import MessageContent
 

--- a/linebot/v3/webhooks/models/beacon_event.py
+++ b/linebot/v3/webhooks/models/beacon_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.beacon_content import BeaconContent
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event

--- a/linebot/v3/webhooks/models/bot_resumed_event.py
+++ b/linebot/v3/webhooks/models/bot_resumed_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/bot_suspended_event.py
+++ b/linebot/v3/webhooks/models/bot_suspended_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/deactivated_event.py
+++ b/linebot/v3/webhooks/models/deactivated_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/detached_module_content.py
+++ b/linebot/v3/webhooks/models/detached_module_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr, validator
+from pydantic.v1 import Field, StrictStr, validator
 from linebot.v3.webhooks.models.module_content import ModuleContent
 
 class DetachedModuleContent(ModuleContent):

--- a/linebot/v3/webhooks/models/event.py
+++ b/linebot/v3/webhooks/models/event.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.webhooks.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/file_message_content.py
+++ b/linebot/v3/webhooks/models/file_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 from linebot.v3.webhooks.models.message_content import MessageContent
 
 class FileMessageContent(MessageContent):

--- a/linebot/v3/webhooks/models/follow_event.py
+++ b/linebot/v3/webhooks/models/follow_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/group_source.py
+++ b/linebot/v3/webhooks/models/group_source.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.source import Source
 
 class GroupSource(Source):

--- a/linebot/v3/webhooks/models/image_message_content.py
+++ b/linebot/v3/webhooks/models/image_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.content_provider import ContentProvider
 from linebot.v3.webhooks.models.image_set import ImageSet
 from linebot.v3.webhooks.models.message_content import MessageContent

--- a/linebot/v3/webhooks/models/join_event.py
+++ b/linebot/v3/webhooks/models/join_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/leave_event.py
+++ b/linebot/v3/webhooks/models/leave_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/link_things_content.py
+++ b/linebot/v3/webhooks/models/link_things_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.things_content import ThingsContent
 
 class LinkThingsContent(ThingsContent):

--- a/linebot/v3/webhooks/models/location_message_content.py
+++ b/linebot/v3/webhooks/models/location_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional, Union
-from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictFloat, StrictInt, StrictStr
 from linebot.v3.webhooks.models.message_content import MessageContent
 
 class LocationMessageContent(MessageContent):

--- a/linebot/v3/webhooks/models/member_joined_event.py
+++ b/linebot/v3/webhooks/models/member_joined_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/member_left_event.py
+++ b/linebot/v3/webhooks/models/member_left_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field
+from pydantic.v1 import Field
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/mentionee.py
+++ b/linebot/v3/webhooks/models/mentionee.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.webhooks.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
 
 class Mentionee(BaseModel):

--- a/linebot/v3/webhooks/models/message_content.py
+++ b/linebot/v3/webhooks/models/message_content.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.webhooks.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class MessageContent(BaseModel):

--- a/linebot/v3/webhooks/models/message_event.py
+++ b/linebot/v3/webhooks/models/message_event.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/module_content.py
+++ b/linebot/v3/webhooks/models/module_content.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.webhooks.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ModuleContent(BaseModel):

--- a/linebot/v3/webhooks/models/module_event.py
+++ b/linebot/v3/webhooks/models/module_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field
+from pydantic.v1 import Field
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/postback_event.py
+++ b/linebot/v3/webhooks/models/postback_event.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/room_source.py
+++ b/linebot/v3/webhooks/models/room_source.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.source import Source
 
 class RoomSource(Source):

--- a/linebot/v3/webhooks/models/scenario_result_things_content.py
+++ b/linebot/v3/webhooks/models/scenario_result_things_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.scenario_result import ScenarioResult
 from linebot.v3.webhooks.models.things_content import ThingsContent
 

--- a/linebot/v3/webhooks/models/source.py
+++ b/linebot/v3/webhooks/models/source.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.webhooks.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class Source(BaseModel):

--- a/linebot/v3/webhooks/models/sticker_message_content.py
+++ b/linebot/v3/webhooks/models/sticker_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr, validator
+from pydantic.v1 import Field, StrictStr, conlist, constr, validator
 from linebot.v3.webhooks.models.message_content import MessageContent
 
 class StickerMessageContent(MessageContent):

--- a/linebot/v3/webhooks/models/text_message_content.py
+++ b/linebot/v3/webhooks/models/text_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import List, Optional
-from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+from pydantic.v1 import Field, StrictStr, conlist
 from linebot.v3.webhooks.models.emoji import Emoji
 from linebot.v3.webhooks.models.mention import Mention
 from linebot.v3.webhooks.models.message_content import MessageContent

--- a/linebot/v3/webhooks/models/things_content.py
+++ b/linebot/v3/webhooks/models/things_content.py
@@ -19,7 +19,7 @@ import json
 import linebot.v3.webhooks.models
 
 
-from typing import Optional
+from typing import Optional, Union
 from pydantic.v1 import BaseModel, Field, StrictStr
 
 class ThingsContent(BaseModel):

--- a/linebot/v3/webhooks/models/things_event.py
+++ b/linebot/v3/webhooks/models/things_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/unfollow_event.py
+++ b/linebot/v3/webhooks/models/unfollow_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel
+
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/unlink_things_content.py
+++ b/linebot/v3/webhooks/models/unlink_things_content.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.things_content import ThingsContent
 
 class UnlinkThingsContent(ThingsContent):

--- a/linebot/v3/webhooks/models/unsend_event.py
+++ b/linebot/v3/webhooks/models/unsend_event.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel
+
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode

--- a/linebot/v3/webhooks/models/user_mentionee.py
+++ b/linebot/v3/webhooks/models/user_mentionee.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.mentionee import Mentionee
 
 class UserMentionee(Mentionee):

--- a/linebot/v3/webhooks/models/user_source.py
+++ b/linebot/v3/webhooks/models/user_source.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.source import Source
 
 class UserSource(Source):

--- a/linebot/v3/webhooks/models/video_message_content.py
+++ b/linebot/v3/webhooks/models/video_message_content.py
@@ -19,7 +19,7 @@ import json
 
 
 from typing import Optional
-from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
+from pydantic.v1 import Field, StrictInt, StrictStr
 from linebot.v3.webhooks.models.content_provider import ContentProvider
 from linebot.v3.webhooks.models.message_content import MessageContent
 

--- a/linebot/v3/webhooks/models/video_play_complete_event.py
+++ b/linebot/v3/webhooks/models/video_play_complete_event.py
@@ -19,7 +19,7 @@ import json
 
 
 
-from pydantic.v1 import BaseModel, Field, StrictStr
+from pydantic.v1 import Field, StrictStr
 from linebot.v3.webhooks.models.delivery_context import DeliveryContext
 from linebot.v3.webhooks.models.event import Event
 from linebot.v3.webhooks.models.event_mode import EventMode


### PR DESCRIPTION
- `getAdditionalProperties()` method was moved to `ModelUtils`.
  - https://github.com/OpenAPITools/openapi-generator/pull/16065
- update `tools/openapi-generator-cli.jar`
  - `wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.0.0/openapi-generator-cli-7.0.0.jar -O tools/openapi-generator-cli.jar`