### PR TITLE
Specify the urllib version explicitly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests ==2.31.0
+urllib3>=2.0.5,<3
 aiohttp ==3.8.6
 future
 pydantic >=2.0.3, <3


### PR DESCRIPTION
To prevent problems from older versions of urllib3.