### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/auto-testing.yml
+++ b/.github/workflows/auto-testing.yml
@@ -14,8 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11']
-
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
     steps:
     - uses: actions/checkout@v4
       with:

--- a/README.rst
+++ b/README.rst
@@ -378,6 +378,7 @@ Test by using tox. We test against the following versions.
 -  3.9
 -  3.10
 -  3.11
+-  3.12
 
 To run all tests and to run ``flake8`` against all versions, use:
 

--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development"
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3.8, py3.9, py3.10, py3.11, py3-flake8-src, py3-flake8-other
+envlist = py3.8, py3.9, py3.10, py3.11, py3.12, py3-flake8-src, py3-flake8-other
 
 [testenv]
 deps =


### PR DESCRIPTION
This change waits for `aiohttp`'s release as 3.9.0, which (will) supports Python 3.12...

https://github.com/aio-libs/aiohttp/issues/7639