### PR TITLE
Relax version in requirement*.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ sphinx>=2
 sphinx_rtd_theme
 pypandoc
 twine
-black>=24.10.0
+black==24.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ sphinx>=2
 sphinx_rtd_theme
 pypandoc
 twine
-black==24.8.0
+black>=24.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.32.3,<3
 urllib3>=2.0.5,<3
-aiohttp ==3.10.9
+aiohttp >=3.10.9
 future
 pydantic >=2.0.3, <3
 aenum >= 3.1.11


### PR DESCRIPTION
Strict version specification can cause issues with dependency updates like https://github.com/line/line-bot-sdk-python/pull/680. 
Some libraries have already relaxed their version constraints (https://github.com/line/line-bot-sdk-python/pull/657), so this adjusts the remaining libraries too.