### PR TITLE
Unsupport Python 3.8

### DIFF
--- a/.github/workflows/auto-testing.yml
+++ b/.github/workflows/auto-testing.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Japanese: https://developers.line.biz/ja/docs/messaging-api/overview/
 Requirements
 ------------
 
--  Python >= 3.8
+-  Python >= 3.9
 
 Installation
 ------------
@@ -408,7 +408,6 @@ Run tests
 
 Test by using tox. We test against the following versions.
 
--  3.8
 -  3.9
 -  3.10
 -  3.11

--- a/generator/src/main/java/line/bot/generator/PythonNextgenCustomClientGenerator.java
+++ b/generator/src/main/java/line/bot/generator/PythonNextgenCustomClientGenerator.java
@@ -1544,7 +1544,7 @@ public class PythonNextgenCustomClientGenerator extends AbstractPythonCodegen im
 
     @Override
     public String generatorLanguageVersion() {
-        return "3.8+";
+        return "3.9+";
     }
 
     @Override

--- a/generator/src/main/resources/python-nextgen-custom-client/github-workflow.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/github-workflow.mustache
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/generator/src/main/resources/python-nextgen-custom-client/pyproject.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/pyproject.mustache
@@ -9,7 +9,7 @@ repository = "https://github.com/{{{gitRepoId}}}/{{{gitUserId}}}"
 keywords = ["OpenAPI", "OpenAPI-Generator", "{{{appName}}}"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 
 urllib3 = ">= 1.25.3"
 python-dateutil = ">=2.8.2"

--- a/generator/src/main/resources/python-nextgen-custom-client/setup.mustache
+++ b/generator/src/main/resources/python-nextgen-custom-client/setup.mustache
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages  # noqa: H301
 # http://pypi.python.org/pypi/setuptools
 NAME = "{{{projectName}}}"
 VERSION = "{{packageVersion}}"
-PYTHON_REQUIRES = ">=3.8"
+PYTHON_REQUIRES = ">=3.9"
 {{#apiInfo}}
 {{#apis}}
 {{#-last}}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ sphinx>=2
 sphinx_rtd_theme
 pypandoc
 twine
-black==24.8.0
+black>=24.10.0

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
     long_description=long_description,
     license='Apache License 2.0',
     packages=find_packages(include=["linebot*"]),
-    python_requires=">=3.8.0",
+    python_requires=">=3.9.0",
     install_requires=_requirements(),
     tests_require=_requirements_test(),
     cmdclass={
@@ -200,7 +200,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3.8, py3.9, py3.10, py3.11, py3.12, py3-flake8-src, py3-flake8-other
+envlist = py3.9, py3.10, py3.11, py3.12, py3-flake8-src, py3-flake8-other
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.8 is EOL.
https://endoflife.date/python

Close https://github.com/line/line-bot-sdk-python/pull/680 because it needs python >= 3.9 and this PR dealt with it.

FYI:
PR which unsupport Python 3.7
https://github.com/line/line-bot-sdk-python/pull/494
https://github.com/line/line-bot-sdk-python/pull/495
