### PR TITLE
Fix other overriding imports

### DIFF
--- a/generator/src/main/java/line/bot/generator/PythonNextgenCustomClientGenerator.java
+++ b/generator/src/main/java/line/bot/generator/PythonNextgenCustomClientGenerator.java
@@ -1368,7 +1368,7 @@ public class PythonNextgenCustomClientGenerator extends AbstractPythonCodegen im
                     modelsToImport.add("from " + packageName + ".models." + underscore(modelImport) + " import " + modelImport);
                 }
 
-                model.getVendorExtensions().putIfAbsent("x-py-model-imports", modelsToImport);
+                model.getVendorExtensions().put("x-py-model-imports", modelsToImport);
             }
         }
 

--- a/linebot/v3/messaging/models/text_message_v2.py
+++ b/linebot/v3/messaging/models/text_message_v2.py
@@ -20,7 +20,6 @@ import json
 
 from typing import Dict, Optional
 from pydantic.v1 import Field, StrictStr
-from linebot.v3.messaging.models.dict[str,_substitution_object] import Dict[str, SubstitutionObject]
 from linebot.v3.messaging.models.message import Message
 from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender


### PR DESCRIPTION
This wil be merged after https://github.com/line/line-bot-sdk-python/pull/702.

## Changes

As mentioned in https://github.com/line/line-bot-sdk-python/pull/702#discussion_r1830725638, `putIfAbsent` does not overwrite values, so it is meaningless.
This change is intended to correct all instances where it is used, although it currently does not affect the generated codes.