### PR TITLE
PR must fail when generated code is not committed

### DIFF
--- a/.github/workflows/generated-code.yml
+++ b/.github/workflows/generated-code.yml
@@ -2,6 +2,7 @@ name: Generate code and open pull request
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - master
@@ -27,7 +28,13 @@ jobs:
           diff=$(git --no-pager diff --name-only HEAD)
           echo "DIFF_IS_EMPTY=$([[ -z "$diff" ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
           echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
-      - if: ${{ env.DIFF_IS_EMPTY != 'true' }}
+      ## Run if diff exists and pull request, and make CI status failure
+      - if: ${{ github.event_name == 'pull_request' && env.DIFF_IS_EMPTY != 'true' }}
+        run: |
+          echo "There are changes in the generated codes. Please run 'generate-code.py' and commit the changes." >&2
+          exit 1
+      ## Run if diff exists and event is not pull request, and make PR
+      - if: ${{ github.event_name != 'pull_request' && env.DIFF_IS_EMPTY != 'true' }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/linebot/v3/messaging/models/text_message_v2.py
+++ b/linebot/v3/messaging/models/text_message_v2.py
@@ -26,8 +26,6 @@ from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender
 from linebot.v3.messaging.models.substitution_object import SubstitutionObject
 
-
-
 class TextMessageV2(Message):
     """
     TextMessageV2

--- a/linebot/v3/messaging/models/text_message_v2.py
+++ b/linebot/v3/messaging/models/text_message_v2.py
@@ -26,6 +26,8 @@ from linebot.v3.messaging.models.quick_reply import QuickReply
 from linebot.v3.messaging.models.sender import Sender
 from linebot.v3.messaging.models.substitution_object import SubstitutionObject
 
+
+
 class TextMessageV2(Message):
     """
     TextMessageV2


### PR DESCRIPTION
When some code are changed by modifying code generator or templates, forgetting to commit the expected changes can lead to mistakes. I want to enforce that the PR author commits the generated code, by causing the CI to fail if the generated code is not committed. This PR achieves that.