### PR TITLE
Open issue when release failed

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -38,6 +38,7 @@ jobs:
         fi
 
         VERSION=${VERSION#v}
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
         python tools/update_version.py $VERSION
     - name: Build and publish
       env:
@@ -46,3 +47,22 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
+
+    - name: Create GitHub Issue on Failure
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { owner, repo } = context.repo;
+          const version = process.env.VERSION;
+          const issueTitle = `Release job for ${version} failed`;
+          const issueBody = `The release job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+          const assignees = [context.actor];
+
+          await github.rest.issues.create({
+            owner,
+            repo,
+            title: issueTitle,
+            body: issueBody,
+            assignees
+          });


### PR DESCRIPTION
When release job fails, we may not realize the issue. Let's open issue to notify us the release job failed.

I've tested this change and it opened an issue like this.
- title contains the release(d) version
- actor is assigned
- description contains failed job url
![image](https://github.com/user-attachments/assets/d2f0464d-2d0f-413a-b0df-da7966289e7e)
