### PR TITLE
Update maven-jar-plugin version 3.4.2

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -49,11 +49,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>jar</goal>
                             <goal>test-jar</goal>
                         </goals>
                     </execution>


### PR DESCRIPTION
By defining the `<goal>jar</goal>`, it was executed twice, resulting in errors like the following CI. I have fixed this and updated the version.
https://github.com/line/line-bot-sdk-python/actions/runs/12023629545/job/33517815259?pr=691#step:5:9205

Close #691 

FYI:
https://stackoverflow.com/questions/40964500/maven-jar-plugin-3-0-2-error-you-have-to-use-a-classifier-to-attach-supplementa