### PR TITLE
Publish library to pypi with OIDC

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -95,8 +95,7 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const version = process.env.VERSION;
-            const issueTitle = `Release job for ${version} failed`;
+            const issueTitle = `Release job for failed`;
             const issueBody = `The release job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
             const assignees = [context.actor];
             

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,10 +13,10 @@ on:
         required: true
 
 jobs:
-  deploy:
-
+  release-build:
     runs-on: ubuntu-latest
-
+    permissions:
+      issues: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -40,13 +40,15 @@ jobs:
         VERSION=${VERSION#v}
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         python tools/update_version.py $VERSION
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_API_USER }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Build
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+
+    - name: upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-dists
+        path: dist/
 
     - name: Create GitHub Issue on Failure
       if: failure()
@@ -66,3 +68,42 @@ jobs:
             body: issueBody,
             assignees
           });
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    environment:
+      name: release
+    permissions:
+      id-token: write
+      issues: write
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+
+      - name: Create GitHub Issue on Failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const version = process.env.VERSION;
+            const issueTitle = `Release job for ${version} failed`;
+            const issueBody = `The release job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+            const assignees = [context.actor];
+            
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: issueTitle,
+              body: issueBody,
+              assignees
+            });


### PR DESCRIPTION
[GitHub supports deployments using OIDC as of 2023](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect). PyPI has also released functionality to integrate with this. As a result, it should be possible to publish without a personal access token.

I have already registered this repository, workflow, and environment with PyPI.
- https://pypi.org/manage/project/line-bot-sdk/settings/publishing/


### reference
- https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-pypi
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://docs.pypi.org/trusted-publishers/