### PR TITLE
Require more jobs in merge queue

### DIFF
--- a/.github/workflows/auto-testing.yml
+++ b/.github/workflows/auto-testing.yml
@@ -7,6 +7,7 @@ on:
   push:
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -1,11 +1,10 @@
 name: Generate code and open pull request
 
 on:
-  workflow_dispatch:
-  pull_request:
   push:
-    branches:
-      - master
+  pull_request:
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
To re-enable the merge queue, this change adds merge_group to several jobs.

original: https://github.com/line/line-bot-sdk-java/pull/1592