### PR TITLE
Set minimumReleaseAge to 7 days to avoid merge renovate PR quickly

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,7 @@
   labels: [
     'dependency upgrade',
   ],
+  minimumReleaseAge : "7 days",
   packageRules: [
     {
       labels: [


### PR DESCRIPTION
It doesn't make any sense if all users delay applying the version upgrade like this, but delaying it compared to others can at least somewhat help in determining the success of the upgrade and identifying dangerous/hacked libraries.

Since we don't publish release very frequently, this should be sufficient.

https://docs.renovatebot.com/configuration-options/#minimumreleaseage

parent: https://github.com/line/line-bot-sdk-nodejs/pull/1387
