### PR TITLE
Update dependency to to v4.31.0 manually

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 -r requirements-test.txt
-tox==4.31.0
+tox==4.31.0 ; python_version >= "3.10"
+tox==4.30.3 ; python_version < "3.10"
 wheel==0.46.1
 Sphinx==7.4.7
 sphinx-rtd-theme==3.0.2


### PR DESCRIPTION
fix #868

The dependency tox v4.31.0 is only compatible with Python 3.10 or later.