### PR TITLE
Deprecate v2

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,751 @@
+# Migration Guide: `linebot` to `linebot.v3`
+
+Starting with version 3.x, the LINE Bot SDK for Python provides a new set of modules under `linebot.v3`. These modules are auto-generated from the [LINE OpenAPI spec](https://github.com/line/line-openapi), making it easy to keep up with future API changes.
+
+The v3 modules are **not backward-compatible** with the previous `linebot` modules, but both coexist in the same package. This means you can migrate your code incrementally — one file or one endpoint at a time.
+
+> **Note:** Only `linebot.v3` will be maintained going forward. The previous `linebot` modules (v2) will not receive updates.
+
+## Table of Contents
+
+- [Migration procedure](#migration-procedure)
+  1. [Upgrade to 3.x](#1-upgrade-to-3x)
+  2. [Replace client construction](#2-replace-client-construction)
+  3. [Update imports and models](#3-update-imports-and-models)
+  4. [Update method calls](#4-update-method-calls)
+  5. [Update webhook handler](#5-update-webhook-handler)
+  6. [Update error handling](#6-update-error-handling)
+  7. [Remove deprecated imports](#7-remove-deprecated-imports)
+- [Full echo-bot before/after example](#full-echo-bot-beforeafter-example)
+- [Client construction mapping](#client-construction-mapping)
+- [Import and type mapping](#import-and-type-mapping)
+- [Method mapping](#method-mapping)
+- [Error handling](#error-handling)
+- [Response headers / x-line-request-id](#response-headers--x-line-request-id)
+- [Suppressing deprecation warnings](#suppressing-deprecation-warnings)
+
+---
+
+## Migration procedure
+
+### 1. Upgrade to 3.x
+
+```bash
+pip install line-bot-sdk>=3.0
+```
+
+Both the deprecated `linebot` modules and the new `linebot.v3` modules are included — no need to install a separate package.
+
+### 2. Replace client construction
+
+**Before (deprecated):**
+
+```python
+from linebot import LineBotApi
+
+line_bot_api = LineBotApi('YOUR_CHANNEL_ACCESS_TOKEN')
+```
+
+**After (v3 — unified client):**
+
+```python
+from linebot.v3 import LineBotClient
+
+line_bot_api = LineBotClient(channel_access_token='YOUR_CHANNEL_ACCESS_TOKEN')
+```
+
+`LineBotClient` is a convenience wrapper that bundles multiple API clients (messaging, audience, insight, liff, module, moduleattach, shop). If you only need the Messaging API, you can also use the individual client directly:
+
+```python
+from linebot.v3.messaging import Configuration, ApiClient, MessagingApi
+
+configuration = Configuration(access_token='YOUR_CHANNEL_ACCESS_TOKEN')
+with ApiClient(configuration) as api_client:
+    messaging_api = MessagingApi(api_client)
+    # use messaging_api...
+```
+
+### 3. Update imports and models
+
+Model names have changed. In general:
+
+- **Send messages:** `TextSendMessage` → `TextMessage` (under `linebot.v3.messaging`)
+- **Webhook messages:** `TextMessage` → `TextMessageContent` (under `linebot.v3.webhooks`)
+- **Sources:** `SourceUser` → `UserSource` (under `linebot.v3.webhooks`)
+
+See [Import and type mapping](#import-and-type-mapping) for the complete table.
+
+### 4. Update method calls
+
+The deprecated API used positional arguments. V3 uses request objects:
+
+**Before (deprecated):**
+
+```python
+line_bot_api.reply_message(
+    event.reply_token,
+    TextSendMessage(text='Hello!')
+)
+```
+
+**After (v3):**
+
+```python
+from linebot.v3.messaging import ReplyMessageRequest, TextMessage
+
+line_bot_api.reply_message(
+    ReplyMessageRequest(
+        reply_token=event.reply_token,
+        messages=[TextMessage(text='Hello!')]
+    )
+)
+```
+
+See [Method mapping](#method-mapping) for the complete table.
+
+### 5. Update webhook handler
+
+The `WebhookHandler` works the same way, but the decorator message type has changed:
+
+**Before (deprecated):**
+
+```python
+from linebot import WebhookHandler
+from linebot.models import MessageEvent, TextMessage
+
+handler = WebhookHandler('YOUR_CHANNEL_SECRET')
+
+@handler.add(MessageEvent, message=TextMessage)
+def handle_message(event):
+    ...
+```
+
+**After (v3):**
+
+```python
+from linebot.v3 import WebhookHandler
+from linebot.v3.webhooks import MessageEvent, TextMessageContent
+
+handler = WebhookHandler('YOUR_CHANNEL_SECRET')
+
+@handler.add(MessageEvent, message=TextMessageContent)
+def handle_message(event):
+    ...
+```
+
+### 6. Update error handling
+
+**Before (deprecated):**
+
+```python
+from linebot.exceptions import LineBotApiError
+
+try:
+    line_bot_api.push_message(to, messages)
+except LineBotApiError as e:
+    print(e.status_code)
+    print(e.error.message)
+    print(e.error.details)
+```
+
+**After (v3):**
+
+```python
+from linebot.v3.messaging.exceptions import ApiException
+
+try:
+    line_bot_api.push_message(push_message_request)
+except ApiException as e:
+    print(e.status)
+    print(e.reason)
+    print(e.body)
+```
+
+### 7. Remove deprecated imports
+
+Once you have migrated all your code and confirmed everything works, remove any remaining imports from the deprecated modules (`linebot.api`, `linebot.models`, `linebot.exceptions`). This eliminates deprecation warnings and ensures your code only depends on maintained modules.
+
+---
+
+## Full echo-bot before/after example
+
+### Before (deprecated)
+
+```python
+from flask import Flask, request, abort
+from linebot import LineBotApi, WebhookHandler
+from linebot.exceptions import InvalidSignatureError
+from linebot.models import MessageEvent, TextMessage, TextSendMessage
+
+app = Flask(__name__)
+
+line_bot_api = LineBotApi('YOUR_CHANNEL_ACCESS_TOKEN')
+handler = WebhookHandler('YOUR_CHANNEL_SECRET')
+
+@app.route("/callback", methods=['POST'])
+def callback():
+    signature = request.headers['X-Line-Signature']
+    body = request.get_data(as_text=True)
+    try:
+        handler.handle(body, signature)
+    except InvalidSignatureError:
+        abort(400)
+    return 'OK'
+
+@handler.add(MessageEvent, message=TextMessage)
+def handle_message(event):
+    line_bot_api.reply_message(
+        event.reply_token,
+        TextSendMessage(text=event.message.text)
+    )
+
+if __name__ == "__main__":
+    app.run()
+```
+
+### After (v3 with handler)
+
+```python
+from flask import Flask, request, abort
+from linebot.v3 import WebhookHandler, LineBotClient
+from linebot.v3.exceptions import InvalidSignatureError
+from linebot.v3.webhooks import MessageEvent, TextMessageContent
+from linebot.v3.messaging import ReplyMessageRequest, TextMessage
+
+app = Flask(__name__)
+
+line_bot_api = LineBotClient(channel_access_token='YOUR_CHANNEL_ACCESS_TOKEN')
+handler = WebhookHandler('YOUR_CHANNEL_SECRET')
+
+@app.route("/callback", methods=['POST'])
+def callback():
+    signature = request.headers['X-Line-Signature']
+    body = request.get_data(as_text=True)
+    try:
+        handler.handle(body, signature)
+    except InvalidSignatureError:
+        abort(400)
+    return 'OK'
+
+@handler.add(MessageEvent, message=TextMessageContent)
+def handle_message(event):
+    line_bot_api.reply_message(
+        ReplyMessageRequest(
+            reply_token=event.reply_token,
+            messages=[TextMessage(text=event.message.text)]
+        )
+    )
+
+if __name__ == "__main__":
+    app.run()
+```
+
+### After (v3 with parser)
+
+```python
+from flask import Flask, request, abort
+from linebot.v3 import WebhookParser, LineBotClient
+from linebot.v3.exceptions import InvalidSignatureError
+from linebot.v3.webhooks import MessageEvent, TextMessageContent
+from linebot.v3.messaging import ReplyMessageRequest, TextMessage
+
+app = Flask(__name__)
+
+line_bot_api = LineBotClient(channel_access_token='YOUR_CHANNEL_ACCESS_TOKEN')
+parser = WebhookParser('YOUR_CHANNEL_SECRET')
+
+@app.route("/callback", methods=['POST'])
+def callback():
+    signature = request.headers['X-Line-Signature']
+    body = request.get_data(as_text=True)
+    try:
+        events = parser.parse(body, signature)
+    except InvalidSignatureError:
+        abort(400)
+
+    for event in events:
+        if not isinstance(event, MessageEvent):
+            continue
+        if not isinstance(event.message, TextMessageContent):
+            continue
+        line_bot_api.reply_message(
+            ReplyMessageRequest(
+                reply_token=event.reply_token,
+                messages=[TextMessage(text=event.message.text)]
+            )
+        )
+    return 'OK'
+
+if __name__ == "__main__":
+    app.run()
+```
+
+### After (v3 async with FastAPI)
+
+```python
+from fastapi import Request, FastAPI, HTTPException
+from linebot.v3 import WebhookParser, AsyncLineBotClient
+from linebot.v3.exceptions import InvalidSignatureError
+from linebot.v3.webhooks import MessageEvent, TextMessageContent
+from linebot.v3.messaging import ReplyMessageRequest, TextMessage
+
+app = FastAPI()
+
+line_bot_api = AsyncLineBotClient(channel_access_token='YOUR_CHANNEL_ACCESS_TOKEN')
+parser = WebhookParser('YOUR_CHANNEL_SECRET')
+
+@app.post("/callback")
+async def handle_callback(request: Request):
+    signature = request.headers['X-Line-Signature']
+    body = (await request.body()).decode()
+
+    try:
+        events = parser.parse(body, signature)
+    except InvalidSignatureError:
+        raise HTTPException(status_code=400, detail="Invalid signature")
+
+    for event in events:
+        if not isinstance(event, MessageEvent):
+            continue
+        if not isinstance(event.message, TextMessageContent):
+            continue
+        await line_bot_api.reply_message(
+            ReplyMessageRequest(
+                reply_token=event.reply_token,
+                messages=[TextMessage(text=event.message.text)]
+            )
+        )
+    return 'OK'
+```
+
+---
+
+## Client construction mapping
+
+| Deprecated | V3 |
+|---|---|
+| `LineBotApi(token)` | `LineBotClient(channel_access_token=token)` |
+| `AsyncLineBotApi(token, async_http_client)` | `AsyncLineBotClient(channel_access_token=token)` |
+
+`LineBotClient` wraps the following API modules: `messaging`, `audience`, `insight`, `liff`, `module`, `moduleattach`, `shop`.
+
+For OAuth / channel access token management, use the separate `linebot.v3.oauth` module.
+
+---
+
+## Import and type mapping
+
+### Send message types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.messaging`) |
+|---|---|
+| `TextSendMessage` | `TextMessage` |
+| `ImageSendMessage` | `ImageMessage` |
+| `VideoSendMessage` | `VideoMessage` |
+| `AudioSendMessage` | `AudioMessage` |
+| `LocationSendMessage` | `LocationMessage` |
+| `StickerSendMessage` | `StickerMessage` |
+| `TemplateSendMessage` | `TemplateMessage` |
+| `FlexSendMessage` | `FlexMessage` |
+| `ImagemapSendMessage` | `ImagemapMessage` |
+
+### Webhook event types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.webhooks`) |
+|---|---|
+| `MessageEvent` | `MessageEvent` |
+| `FollowEvent` | `FollowEvent` |
+| `UnfollowEvent` | `UnfollowEvent` |
+| `JoinEvent` | `JoinEvent` |
+| `LeaveEvent` | `LeaveEvent` |
+| `PostbackEvent` | `PostbackEvent` |
+| `AccountLinkEvent` | `AccountLinkEvent` |
+| `MemberJoinedEvent` | `MemberJoinedEvent` |
+| `MemberLeftEvent` | `MemberLeftEvent` |
+| `BeaconEvent` | `BeaconEvent` |
+| `VideoPlayCompleteEvent` | `VideoPlayCompleteEvent` |
+| `UnsendEvent` | `UnsendEvent` |
+
+### Webhook message content types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.webhooks`) |
+|---|---|
+| `TextMessage` | `TextMessageContent` |
+| `ImageMessage` | `ImageMessageContent` |
+| `VideoMessage` | `VideoMessageContent` |
+| `AudioMessage` | `AudioMessageContent` |
+| `LocationMessage` | `LocationMessageContent` |
+| `StickerMessage` | `StickerMessageContent` |
+| `FileMessage` | `FileMessageContent` |
+
+### Webhook other content types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.webhooks`) |
+|---|---|
+| `Postback` | `PostbackContent` |
+| `Beacon` | `BeaconContent` |
+
+### Source types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.webhooks`) |
+|---|---|
+| `SourceUser` | `UserSource` |
+| `SourceGroup` | `GroupSource` |
+| `SourceRoom` | `RoomSource` |
+
+### Template types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.messaging`) |
+|---|---|
+| `ButtonsTemplate` | `ButtonsTemplate` |
+| `ConfirmTemplate` | `ConfirmTemplate` |
+| `CarouselTemplate` | `CarouselTemplate` |
+| `CarouselColumn` | `CarouselColumn` |
+| `ImageCarouselTemplate` | `ImageCarouselTemplate` |
+| `ImageCarouselColumn` | `ImageCarouselColumn` |
+
+### Action types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.messaging`) | Notes |
+|---|---|---|
+| `PostbackAction` | `PostbackAction` | |
+| `MessageAction` | `MessageAction` | |
+| `URIAction` | `URIAction` | |
+| `DatetimePickerAction` | `DatetimePickerAction` | |
+| `CameraAction` | `CameraAction` | |
+| `CameraRollAction` | `CameraRollAction` | |
+| `LocationAction` | `LocationAction` | |
+| `RichMenuSwitchAction` | `RichMenuSwitchAction` | |
+| `AltUri` | `AltUri` | |
+| `PostbackTemplateAction` | `PostbackAction` | Alias removed |
+| `MessageTemplateAction` | `MessageAction` | Alias removed |
+| `URITemplateAction` | `URIAction` | Alias removed |
+| `DatetimePickerTemplateAction` | `DatetimePickerAction` | Alias removed |
+
+### Flex message types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.messaging`) | Notes |
+|---|---|---|
+| `BubbleContainer` | `FlexBubble` | Renamed |
+| `CarouselContainer` | `FlexCarousel` | Renamed |
+| `BubbleStyle` | `FlexBubbleStyles` | Renamed (added `s`) |
+| `BlockStyle` | `FlexBlockStyle` | Renamed |
+| `BoxComponent` | `FlexBox` | Renamed |
+| `ButtonComponent` | `FlexButton` | Renamed |
+| `FillerComponent` | `FlexFiller` | Renamed |
+| `IconComponent` | `FlexIcon` | Renamed |
+| `ImageComponent` | `FlexImage` | Renamed |
+| `SeparatorComponent` | `FlexSeparator` | Renamed |
+| `TextComponent` | `FlexText` | Renamed |
+| `SpanComponent` | `FlexSpan` | Renamed |
+| `VideoComponent` | `FlexVideo` | Renamed |
+| `LinearGradientBackground` | `FlexBoxLinearGradient` | Renamed |
+
+### Imagemap types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.messaging`) | Notes |
+|---|---|---|
+| `URIImagemapAction` | `URIImagemapAction` | |
+| `MessageImagemapAction` | `MessageImagemapAction` | |
+| `ImagemapArea` | `ImagemapArea` | |
+| `BaseSize` | `ImagemapBaseSize` | Renamed |
+| `Video` | `ImagemapVideo` | Renamed |
+| `ExternalLink` | `ImagemapExternalLink` | Renamed |
+
+### Quick reply types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.messaging`) | Notes |
+|---|---|---|
+| `QuickReply` | `QuickReply` | |
+| `QuickReplyButton` | `QuickReplyItem` | Renamed |
+
+### Rich menu types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.messaging`) | Notes |
+|---|---|---|
+| `RichMenu` | `RichMenuRequest` | Renamed |
+| `RichMenuSize` | `RichMenuSize` | |
+| `RichMenuArea` | `RichMenuArea` | |
+| `RichMenuBounds` | `RichMenuBounds` | |
+| `RichMenuResponse` | `RichMenuResponse` | |
+| `RichMenuAlias` | `RichMenuAliasResponse` | Renamed |
+
+### Response types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.messaging`) | Notes |
+|---|---|---|
+| `Profile` | `UserProfileResponse` | Renamed |
+| `BotInfo` | `BotInfoResponse` | Renamed |
+| `Group` (from `get_group_summary`) | `GroupSummaryResponse` | Renamed |
+| `MemberIds` | `MembersIdsResponse` | Renamed |
+| `Content` / `MessageContent` | `bytearray` (via `MessagingApiBlob`) | Different return type |
+| `MessageQuotaResponse` | `MessageQuotaResponse` | |
+| `MessageQuotaConsumptionResponse` | `QuotaConsumptionResponse` | Renamed |
+| `IssueLinkTokenResponse` | `IssueLinkTokenResponse` | |
+| `GetWebhookResponse` | `GetWebhookEndpointResponse` | Renamed |
+| `TestWebhookResponse` | `TestWebhookEndpointResponse` | Renamed |
+| `MessageProgressNarrowcastResponse` | `NarrowcastProgressResponse` | Renamed |
+| `MessageDeliveryBroadcastResponse` | `NumberOfMessagesResponse` | Renamed |
+| `MessageDeliveryReplyResponse` | `NumberOfMessagesResponse` | Renamed |
+| `MessageDeliveryPushResponse` | `NumberOfMessagesResponse` | Renamed |
+| `MessageDeliveryMulticastResponse` | `NumberOfMessagesResponse` | Renamed |
+
+### Insight response types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.insight`) | Notes |
+|---|---|---|
+| `InsightMessageDeliveryResponse` | `GetNumberOfMessageDeliveriesResponse` | Renamed |
+| `InsightFollowersResponse` | `GetNumberOfFollowersResponse` | Renamed |
+| `InsightDemographicResponse` | `GetFriendsDemographicsResponse` | Renamed |
+| `InsightMessageEventResponse` | `GetMessageEventResponse` | Renamed |
+
+### Filter / narrowcast types
+
+| Deprecated (`linebot.models`) | V3 (`linebot.v3.messaging`) | Notes |
+|---|---|---|
+| `GenderFilter` | `GenderDemographicFilter` | Renamed |
+| `AppTypeFilter` | `AppTypeDemographicFilter` | Renamed |
+| `AreaFilter` | `AreaDemographicFilter` | Renamed |
+| `AgeFilter` | `AgeDemographicFilter` | Renamed |
+| `SubscriptionPeriodFilter` | `SubscriptionPeriodDemographicFilter` | Renamed |
+| `AudienceRecipient` | `AudienceRecipient` | |
+| `RedeliveryRecipient` | `RedeliveryRecipient` | |
+
+### Other types
+
+| Deprecated (`linebot.models`) | V3 | Notes |
+|---|---|---|
+| `Sender` | `linebot.v3.messaging.Sender` | |
+| `Emojis` | `linebot.v3.messaging.Emoji` | Renamed |
+| `Error` | `linebot.v3.messaging.ErrorResponse` | Renamed |
+| `ErrorDetail` | `linebot.v3.messaging.ErrorDetail` | |
+
+### Exception classes
+
+| Deprecated (`linebot.exceptions`) | V3 |
+|---|---|
+| `InvalidSignatureError` | `linebot.v3.exceptions.InvalidSignatureError` |
+| `LineBotApiError` | `linebot.v3.messaging.exceptions.ApiException` |
+
+---
+
+## Method mapping
+
+All V3 methods also have a `_with_http_info` variant (e.g. `reply_message_with_http_info(...)`) that returns the response headers along with the response body. See [Response headers](#response-headers--x-line-request-id).
+
+### Messaging
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `reply_message(reply_token, messages, ...)` | `reply_message(ReplyMessageRequest(...))` | Positional args → request object |
+| `push_message(to, messages, ...)` | `push_message(PushMessageRequest(...))` | |
+| `multicast(to, messages, ...)` | `multicast(MulticastRequest(...))` | |
+| `broadcast(messages, ...)` | `broadcast(BroadcastRequest(...))` | |
+| `narrowcast(messages, ...)` | `narrowcast(NarrowcastRequest(...))` | |
+
+### Message validation
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `validate_reply_message_objects(messages)` | `validate_reply(ValidateMessageRequest(...))` | Renamed |
+| `validate_push_message_objects(messages)` | `validate_push(ValidateMessageRequest(...))` | Renamed |
+| `validate_multicast_message_objects(messages)` | `validate_multicast(ValidateMessageRequest(...))` | Renamed |
+| `validate_broadcast_message_objects(messages)` | `validate_broadcast(ValidateMessageRequest(...))` | Renamed |
+| `validate_narrowcast_message_objects(messages)` | `validate_narrowcast(ValidateMessageRequest(...))` | Renamed |
+
+### Profile and group management
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `get_profile(user_id)` | `get_profile(user_id)` | Unchanged |
+| `get_group_summary(group_id)` | `get_group_summary(group_id)` | Unchanged |
+| `get_group_member_profile(group_id, user_id)` | `get_group_member_profile(group_id, user_id)` | Unchanged |
+| `get_room_member_profile(room_id, user_id)` | `get_room_member_profile(room_id, user_id)` | Unchanged |
+| `get_group_members_count(group_id)` | `get_group_member_count(group_id)` | Renamed (removed `s`) |
+| `get_room_members_count(room_id)` | `get_room_member_count(room_id)` | Renamed (removed `s`) |
+| `get_group_member_ids(group_id, start)` | `get_group_members_ids(group_id, start)` | Renamed (added `s`) |
+| `get_room_member_ids(room_id, start)` | `get_room_members_ids(room_id, start)` | Renamed (added `s`) |
+| `get_followers_ids(limit, start)` | `get_followers(start, limit)` | Renamed, parameter order changed |
+| `get_bot_info()` | `get_bot_info()` | Unchanged |
+| `leave_group(group_id)` | `leave_group(group_id)` | Unchanged |
+| `leave_room(room_id)` | `leave_room(room_id)` | Unchanged |
+
+### Message content
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `get_message_content(message_id)` | `get_message_content(message_id)` | Returns `bytearray` instead of `Content` |
+
+### Rich menu management
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `get_rich_menu(rich_menu_id)` | `get_rich_menu(rich_menu_id)` | Unchanged |
+| `create_rich_menu(rich_menu)` | `create_rich_menu(RichMenuRequest(...))` | Uses request object |
+| `delete_rich_menu(rich_menu_id)` | `delete_rich_menu(rich_menu_id)` | Unchanged |
+| `get_rich_menu_alias(rich_menu_alias_id)` | `get_rich_menu_alias(rich_menu_alias_id)` | Unchanged |
+| `get_rich_menu_alias_list()` | `get_rich_menu_alias_list()` | Unchanged |
+| `create_rich_menu_alias(rich_menu_alias)` | `create_rich_menu_alias(CreateRichMenuAliasRequest(...))` | Uses request object |
+| `update_rich_menu_alias(id, alias)` | `update_rich_menu_alias(id, UpdateRichMenuAliasRequest(...))` | Uses request object |
+| `delete_rich_menu_alias(id)` | `delete_rich_menu_alias(id)` | Unchanged |
+| `validate_rich_menu_object(rich_menu)` | `validate_rich_menu_object(RichMenuRequest(...))` | Uses request object |
+| `get_rich_menu_id_of_user(user_id)` | `get_rich_menu_id_of_user(user_id)` | Unchanged |
+| `link_rich_menu_to_user(user_id, rich_menu_id)` | `link_rich_menu_id_to_user(user_id, rich_menu_id)` | Renamed |
+| `unlink_rich_menu_from_user(user_id)` | `unlink_rich_menu_id_from_user(user_id)` | Renamed |
+| `link_rich_menu_to_users(user_ids, rich_menu_id)` | `link_rich_menu_id_to_users(RichMenuBulkLinkRequest(...))` | Renamed, uses request object |
+| `unlink_rich_menu_from_users(user_ids)` | `unlink_rich_menu_id_from_users(RichMenuBulkUnlinkRequest(...))` | Renamed, uses request object |
+| `get_rich_menu_image(rich_menu_id)` | `get_rich_menu_image(rich_menu_id)` | Unchanged |
+| `set_rich_menu_image(id, content_type, content)` | `set_rich_menu_image(id, body)` | `content_type` removed |
+| `get_rich_menu_list()` | `get_rich_menu_list()` | Unchanged |
+| `set_default_rich_menu(rich_menu_id)` | `set_default_rich_menu(rich_menu_id)` | Unchanged |
+| `get_default_rich_menu()` | `get_default_rich_menu_id()` | Renamed |
+| `cancel_default_rich_menu()` | `cancel_default_rich_menu()` | Unchanged |
+
+### Webhook endpoint management
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `set_webhook_endpoint(url)` | `set_webhook_endpoint(SetWebhookEndpointRequest(...))` | Uses request object |
+| `get_webhook_endpoint()` | `get_webhook_endpoint()` | Unchanged |
+| `test_webhook_endpoint(url)` | `test_webhook_endpoint(TestWebhookEndpointRequest(...))` | Uses request object |
+
+### Link token
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `issue_link_token(user_id)` | `issue_link_token(user_id)` | Unchanged |
+
+### Message delivery statistics
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `get_message_delivery_reply(date)` | `get_number_of_sent_reply_messages(date)` | Renamed |
+| `get_message_delivery_push(date)` | `get_number_of_sent_push_messages(date)` | Renamed |
+| `get_message_delivery_multicast(date)` | `get_number_of_sent_multicast_messages(date)` | Renamed |
+| `get_message_delivery_broadcast(date)` | `get_number_of_sent_broadcast_messages(date)` | Renamed |
+| `get_progress_status_narrowcast(request_id)` | `get_narrowcast_progress(request_id)` | Renamed |
+| `get_message_quota()` | `get_message_quota()` | Unchanged |
+| `get_message_quota_consumption()` | `get_message_quota_consumption()` | Unchanged |
+| `get_number_of_units_used_this_month()` | `get_aggregation_unit_usage()` | Renamed |
+| `get_name_list_of_units_used_this_month(limit, start)` | `get_aggregation_unit_name_list(limit, start)` | Renamed |
+
+### Insight API
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `get_insight_message_delivery(date)` | `get_number_of_message_deliveries(date)` | Renamed |
+| `get_insight_followers(date)` | `get_number_of_followers(date)` | Renamed |
+| `get_insight_demographic()` | `get_friends_demographics()` | Renamed |
+| `get_insight_message_event(request_id)` | `get_message_event(request_id)` | Renamed |
+| `get_statistics_per_unit(unit, from_date, to_date)` | `get_statistics_per_unit(unit, from, to)` | Unchanged |
+
+### Audience management
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| `create_audience_group(name, audiences, is_ifa)` | `create_audience_group(CreateAudienceGroupRequest(...))` | Uses request object |
+| `get_audience_group(audience_group_id)` | `get_audience_data(audience_group_id)` | Renamed |
+| `get_audience_group_list(page, ...)` | `get_audience_groups(page, ...)` | Renamed |
+| `delete_audience_group(audience_group_id)` | `delete_audience_group(audience_group_id)` | Unchanged |
+| `rename_audience_group(id, description)` | `update_audience_group_description(id, UpdateAudienceGroupDescriptionRequest(...))` | Renamed, uses request object |
+| `add_audiences_to_audience_group(id, audiences, ...)` | `add_audience_to_audience_group(AddAudienceToAudienceGroupRequest(...))` | Renamed, uses request object |
+| `create_click_audience_group(desc, request_id, url)` | `create_click_based_audience_group(CreateClickBasedAudienceGroupRequest(...))` | Renamed, uses request object |
+| `create_imp_audience_group(desc, request_id)` | `create_imp_based_audience_group(CreateImpBasedAudienceGroupRequest(...))` | Renamed, uses request object |
+| `get_audience_group_authority_level()` | _(removed)_ | No V3 equivalent |
+| `change_audience_group_authority_level(level)` | _(removed)_ | No V3 equivalent |
+
+### LIFF
+
+| Deprecated (`LineBotApi`) | V3 (`LineBotClient`) | Notes |
+|---|---|---|
+| _(not in deprecated API)_ | `add_liff_app(AddLiffAppRequest(...))` | New in v3 |
+| _(not in deprecated API)_ | `update_liff_app(liff_id, UpdateLiffAppRequest(...))` | New in v3 |
+| _(not in deprecated API)_ | `delete_liff_app(liff_id)` | New in v3 |
+| _(not in deprecated API)_ | `get_all_liff_apps()` | New in v3 |
+
+### OAuth / Channel access token
+
+OAuth methods that were on `LineBotApi` have been moved to a separate module in v3:
+
+| Deprecated (`LineBotApi`) | V3 (`linebot.v3.oauth.ChannelAccessToken`) | Notes |
+|---|---|---|
+| `issue_channel_token(client_id, client_secret)` | `issue_channel_token(grant_type, client_id, client_secret)` | `grant_type` now explicit |
+| `revoke_channel_token(access_token)` | `revoke_channel_token(access_token)` | Unchanged |
+| `issue_channel_access_token_v2_1(client_assertion)` | `issue_channel_token_by_jwt(grant_type, client_assertion_type, client_assertion)` | Renamed, args now explicit |
+| `revoke_channel_access_token_v2_1(client_id, client_secret, access_token)` | `revoke_channel_token_by_jwt(client_id, client_secret, access_token)` | Renamed |
+| `verify_channel_access_token_v2_1(access_token)` | `verify_channel_token_by_jwt(access_token)` | Renamed |
+| `get_channel_token_key_ids_v2_1(client_assertion)` | `gets_all_valid_channel_access_token_key_ids(client_assertion_type, client_assertion)` | Renamed |
+| `get_channel_access_tokens_v2_1(client_assertion)` | _(removed)_ | No V3 equivalent |
+
+---
+
+## Error handling
+
+### Before (deprecated)
+
+```python
+from linebot.exceptions import LineBotApiError
+
+try:
+    line_bot_api.push_message('USER_ID', TextSendMessage(text='Hello!'))
+except LineBotApiError as e:
+    print(e.status_code)      # HTTP status code (e.g. 400)
+    print(e.request_id)       # X-Line-Request-Id
+    print(e.error.message)    # Error message from API
+    print(e.error.details)    # List of error details
+```
+
+### After (v3)
+
+```python
+from linebot.v3.messaging import PushMessageRequest, TextMessage
+from linebot.v3.messaging.exceptions import ApiException
+
+try:
+    line_bot_api.push_message(
+        PushMessageRequest(
+            to='USER_ID',
+            messages=[TextMessage(text='Hello!')]
+        )
+    )
+except ApiException as e:
+    print(e.status)    # HTTP status code (e.g. 400)
+    print(e.reason)    # Reason phrase
+    print(e.headers)   # Response headers (includes x-line-request-id)
+    print(e.body)      # Response body as string
+```
+
+---
+
+## Response headers / x-line-request-id
+
+In the deprecated API, `x-line-request-id` was only accessible through `LineBotApiError`. In v3, use the `_with_http_info` methods to access response headers for successful requests:
+
+```python
+from linebot.v3.messaging import ReplyMessageRequest, TextMessage
+
+response = line_bot_api.reply_message_with_http_info(
+    ReplyMessageRequest(
+        reply_token=event.reply_token,
+        messages=[TextMessage(text='Hello!')]
+    )
+)
+
+print(response.status_code)                     # HTTP status code
+print(response.headers.get('x-line-request-id')) # Request ID
+```
+
+---
+
+## Suppressing deprecation warnings
+
+During migration, you may see deprecation warnings when using the old `linebot` modules. To suppress them:
+
+```python
+import warnings
+from linebot import LineBotSdkDeprecatedIn30
+
+warnings.filterwarnings("ignore", category=LineBotSdkDeprecatedIn30)
+```
+
+> **Tip:** Only suppress these warnings temporarily. Once your migration is complete, remove both the warning filter and the deprecated imports.

--- a/README.rst
+++ b/README.rst
@@ -356,6 +356,8 @@ To utilize the latest features, we recommend you gradually transition to ``lineb
 While we won't update ``linebot`` modules anymore, users can still continue to use the version 2.x ``linebot`` modules.
 We also welcome pull requests for the version ``2.x`` and ``3.x`` modules.
 
+For a step-by-step migration guide with before/after examples, see `MIGRATION.md <MIGRATION.md>`__.
+
 
 How to suppress deprecation warnings
 ------------------------------------

--- a/linebot/aiohttp_async_http_client.py
+++ b/linebot/aiohttp_async_http_client.py
@@ -16,7 +16,11 @@
 
 from linebot import AsyncHttpClient, AsyncHttpResponse
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AiohttpAsyncHttpClient(AsyncHttpClient):
     """HttpClient implemented by requests."""
 
@@ -113,6 +117,7 @@ class AiohttpAsyncHttpClient(AsyncHttpClient):
         return AiohttpAsyncHttpResponse(response)
 
 
+@deprecated(reason="Use 'linebot.v3' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AiohttpAsyncHttpResponse(AsyncHttpResponse):
     """AsyncHttpResponse implemented by aiohttp's response."""
 

--- a/linebot/api.py
+++ b/linebot/api.py
@@ -46,7 +46,7 @@ from .deprecations import (
 from deprecated import deprecated
 
 
-@deprecated(reason="Use v3 class; linebot.v3.<feature>. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+@deprecated(reason="Use 'from linebot.v3 import LineBotClient'. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class LineBotApi(object):
     """LineBotApi provides interface for LINE messaging API."""
 
@@ -82,7 +82,7 @@ class LineBotApi(object):
         else:
             self.http_client = RequestsHttpClient(timeout=timeout)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).reply_message(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).reply_message(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def reply_message(self, reply_token, messages, notification_disabled=False, timeout=None):
         """Call reply message API.
 
@@ -124,7 +124,7 @@ class LineBotApi(object):
             '/v2/bot/message/reply', data=json.dumps(data), timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).push_message(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).push_message(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def push_message(
             self, to, messages,
             retry_key=None, notification_disabled=False,
@@ -175,7 +175,7 @@ class LineBotApi(object):
             '/v2/bot/message/push', data=json.dumps(data), timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).multicast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).multicast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def multicast(self, to, messages, retry_key=None, notification_disabled=False,
                   custom_aggregation_units=None, timeout=None):
         """Call multicast API.
@@ -227,7 +227,7 @@ class LineBotApi(object):
             '/v2/bot/message/multicast', data=json.dumps(data), timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).broadcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).broadcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def broadcast(self, messages, retry_key=None, notification_disabled=False, timeout=None):
         """Call broadcast API.
 
@@ -266,7 +266,7 @@ class LineBotApi(object):
 
         return BroadcastResponse(request_id=response.headers.get('X-Line-Request-Id'))
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).narrowcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).narrowcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def narrowcast(
             self, messages,
             retry_key=None, recipient=None, filter=None, limit=None,
@@ -318,7 +318,7 @@ class LineBotApi(object):
 
         return NarrowcastResponse(request_id=response.headers.get('X-Line-Request-Id'))
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_narrowcast_progress(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_narrowcast_progress(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_progress_status_narrowcast(self, request_id, timeout=None):
         """Get progress status of narrowcast messages sent.
 
@@ -342,7 +342,7 @@ class LineBotApi(object):
 
         return MessageProgressNarrowcastResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).validate_reply(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).validate_reply(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def validate_reply_message_objects(self, messages, timeout=None):
         """Call validate reply message objects API.
 
@@ -377,7 +377,7 @@ class LineBotApi(object):
         return ValidateReplyMessageObjectsResponse(
             request_id=response.headers.get('X-Line-Request-Id'))
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).validate_push(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).validate_push(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def validate_push_message_objects(self, messages, timeout=None):
         """Call validate push message objects API.
 
@@ -412,7 +412,7 @@ class LineBotApi(object):
         return ValidatePushMessageObjectsResponse(
             request_id=response.headers.get('X-Line-Request-Id'))
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).validate_multicast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).validate_multicast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def validate_multicast_message_objects(self, messages, timeout=None):
         """Call validate multicast message objects API.
 
@@ -447,7 +447,7 @@ class LineBotApi(object):
         return ValidateMulticastMessageObjectsResponse(
             request_id=response.headers.get('X-Line-Request-Id'))
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).validate_broadcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).validate_broadcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def validate_broadcast_message_objects(self, messages, timeout=None):
         """Call validate broadcast message objects API.
 
@@ -482,7 +482,7 @@ class LineBotApi(object):
         return ValidateBroadcastMessageObjectsResponse(
             request_id=response.headers.get('X-Line-Request-Id'))
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).validate_narrowcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).validate_narrowcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def validate_narrowcast_message_objects(self, messages, timeout=None):
         """Call validate narrowcast message objects API.
 
@@ -517,7 +517,7 @@ class LineBotApi(object):
         return ValidateNarrowcastMessageObjectsResponse(
             request_id=response.headers.get('X-Line-Request-Id'))
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_number_of_sent_broadcast_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_number_of_sent_broadcast_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_message_delivery_broadcast(self, date, timeout=None):
         """Get number of sent broadcast messages.
 
@@ -540,7 +540,7 @@ class LineBotApi(object):
 
         return MessageDeliveryBroadcastResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_number_of_sent_reply_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_number_of_sent_reply_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_message_delivery_reply(self, date, timeout=None):
         """Get number of sent reply messages.
 
@@ -563,7 +563,7 @@ class LineBotApi(object):
 
         return MessageDeliveryReplyResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_number_of_sent_push_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_number_of_sent_push_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_message_delivery_push(self, date, timeout=None):
         """Get number of sent push messages.
 
@@ -586,7 +586,7 @@ class LineBotApi(object):
 
         return MessageDeliveryPushResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_number_of_sent_multicast_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_number_of_sent_multicast_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_message_delivery_multicast(self, date, timeout=None):
         """Get number of sent multicast messages.
 
@@ -609,7 +609,7 @@ class LineBotApi(object):
 
         return MessageDeliveryMulticastResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_profile(self, user_id, timeout=None):
         """Call get profile API.
 
@@ -633,7 +633,7 @@ class LineBotApi(object):
 
         return Profile.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_group_summary(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_group_summary(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_group_summary(self, group_id, timeout=None):
         """Call get group summary API.
 
@@ -658,7 +658,7 @@ class LineBotApi(object):
 
         return Group.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_group_member_count(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_group_member_count(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_group_members_count(self, group_id, timeout=None):
         """Call get members in group count API.
 
@@ -682,7 +682,7 @@ class LineBotApi(object):
 
         return response.json.get('count')
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_room_member_count(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_room_member_count(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_room_members_count(self, room_id, timeout=None):
         """Call get members in room count API.
 
@@ -706,7 +706,7 @@ class LineBotApi(object):
 
         return response.json.get('count')
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_group_member_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_group_member_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_group_member_profile(self, group_id, user_id, timeout=None):
         """Call get group member profile API.
 
@@ -733,7 +733,7 @@ class LineBotApi(object):
 
         return Profile.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_room_member_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_room_member_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_room_member_profile(self, room_id, user_id, timeout=None):
         """Call get room member profile API.
 
@@ -760,7 +760,7 @@ class LineBotApi(object):
 
         return Profile.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_group_members_ids(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_group_members_ids(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_group_member_ids(self, group_id, start=None, timeout=None):
         """Call get group member IDs API.
 
@@ -790,7 +790,7 @@ class LineBotApi(object):
 
         return MemberIds.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_room_members_ids(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_room_members_ids(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_room_member_ids(self, room_id, start=None, timeout=None):
         """Call get room member IDs API.
 
@@ -820,7 +820,7 @@ class LineBotApi(object):
 
         return MemberIds.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApiBlob' and 'MessagingApiBlob(...).get_message_content(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_message_content(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_message_content(self, message_id, timeout=None):
         """Call get content API.
 
@@ -844,7 +844,7 @@ class LineBotApi(object):
 
         return Content(response)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).leave_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).leave_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def leave_group(self, group_id, timeout=None):
         """Call leave group API.
 
@@ -864,7 +864,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).leave_room(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).leave_room(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def leave_room(self, room_id, timeout=None):
         """Call leave room API.
 
@@ -884,7 +884,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_rich_menu(self, rich_menu_id, timeout=None):
         """Call get rich menu API.
 
@@ -906,7 +906,7 @@ class LineBotApi(object):
 
         return RichMenuResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_rich_menu_alias(self, rich_menu_alias_id=None, timeout=None):
         """Call get rich menu alias API.
 
@@ -927,7 +927,7 @@ class LineBotApi(object):
         )
         return RichMenuAliasResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_rich_menu_alias_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_rich_menu_alias_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_rich_menu_alias_list(self, timeout=None):
         """Call get rich menu alias list API.
 
@@ -947,7 +947,7 @@ class LineBotApi(object):
         )
         return RichMenuAliasListResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).validate_rich_menu_object(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).validate_rich_menu_object(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def validate_rich_menu_object(self, rich_menu, timeout=None):
         """Call validate rich menu object API.
 
@@ -966,7 +966,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).create_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).create_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def create_rich_menu(self, rich_menu, timeout=None):
         """Call create rich menu API.
 
@@ -988,7 +988,7 @@ class LineBotApi(object):
 
         return response.json.get('richMenuId')
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).create_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).create_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def create_rich_menu_alias(self, rich_menu_alias, timeout=None):
         """Call create rich menu alias API.
 
@@ -1008,7 +1008,7 @@ class LineBotApi(object):
             '/v2/bot/richmenu/alias', data=rich_menu_alias.as_json_string(), timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).update_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).update_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def update_rich_menu_alias(self, rich_menu_alias_id, rich_menu_alias, timeout=None):
         """Call update rich menu alias API.
 
@@ -1031,7 +1031,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).delete_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).delete_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def delete_rich_menu(self, rich_menu_id, timeout=None):
         """Call delete rich menu API.
 
@@ -1049,7 +1049,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).delete_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).delete_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def delete_rich_menu_alias(self, rich_menu_alias_id, timeout=None):
         """Call delete rich menu alias API.
 
@@ -1068,7 +1068,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_rich_menu_id_of_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_rich_menu_id_of_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_rich_menu_id_of_user(self, user_id, timeout=None):
         """Call get rich menu ID of user API.
 
@@ -1090,7 +1090,7 @@ class LineBotApi(object):
 
         return response.json.get('richMenuId')
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).link_rich_menu_id_to_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).link_rich_menu_id_to_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def link_rich_menu_to_user(self, user_id, rich_menu_id, timeout=None):
         """Call link rich menu to user API.
 
@@ -1112,7 +1112,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).link_rich_menu_id_to_users(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).link_rich_menu_id_to_users(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def link_rich_menu_to_users(self, user_ids, rich_menu_id, timeout=None):
         """Links a rich menu to multiple users.
 
@@ -1137,7 +1137,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).unlink_rich_menu_id_from_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).unlink_rich_menu_id_from_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def unlink_rich_menu_from_user(self, user_id, timeout=None):
         """Call unlink rich menu from user API.
 
@@ -1155,7 +1155,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).unlink_rich_menu_id_from_users(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).unlink_rich_menu_id_from_users(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def unlink_rich_menu_from_users(self, user_ids, timeout=None):
         """Unlinks rich menus from multiple users.
 
@@ -1178,7 +1178,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApiBlob' and 'MessagingApiBlob.get_rich_menu_image(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_rich_menu_image(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_rich_menu_image(self, rich_menu_id, timeout=None):
         """Call download rich menu image API.
 
@@ -1200,7 +1200,7 @@ class LineBotApi(object):
 
         return Content(response)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApiBlob' and 'MessagingApiBlob.set_rich_menu_image(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).set_rich_menu_image(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def set_rich_menu_image(self, rich_menu_id, content_type, content, timeout=None):
         """Call upload rich menu image API.
 
@@ -1225,7 +1225,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_rich_menu_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_rich_menu_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_rich_menu_list(self, timeout=None):
         """Call get rich menu list API.
 
@@ -1250,7 +1250,7 @@ class LineBotApi(object):
 
         return result
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).set_default_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).set_default_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def set_default_rich_menu(self, rich_menu_id, timeout=None):
         """Set the default rich menu.
 
@@ -1270,7 +1270,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_default_rich_menu_id(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_default_rich_menu_id(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_default_rich_menu(self, timeout=None):
         """Get the ID of the default rich menu set with the Messaging API.
 
@@ -1289,7 +1289,7 @@ class LineBotApi(object):
 
         return response.json.get('richMenuId')
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).cancel_default_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).cancel_default_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def cancel_default_rich_menu(self, timeout=None):
         """Cancel the default rich menu set with the Messaging API.
 
@@ -1306,7 +1306,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_message_quota(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_message_quota(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_message_quota(self, timeout=None):
         """Call Get the target limit for additional messages.
 
@@ -1327,7 +1327,7 @@ class LineBotApi(object):
 
         return MessageQuotaResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_message_quota_consumption(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_message_quota_consumption(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_message_quota_consumption(self, timeout=None):
         """Get number of messages sent this month.
 
@@ -1348,7 +1348,7 @@ class LineBotApi(object):
 
         return MessageQuotaConsumptionResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).issue_link_token(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).issue_link_token(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def issue_link_token(self, user_id, timeout=None):
         """Issues a link token used for the account link feature.
 
@@ -1423,7 +1423,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.insight import Insight' and 'Insight(...).get_number_of_message_deliveries(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_number_of_message_deliveries(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_insight_message_delivery(self, date, timeout=None):
         """Get the number of messages sent on a specified day.
 
@@ -1444,7 +1444,7 @@ class LineBotApi(object):
 
         return InsightMessageDeliveryResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.insight import Insight' and 'Insight(...).get_insight_followers(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_insight_followers(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_insight_followers(self, date, timeout=None):
         """Get the number of users who have added the bot on or before a specified date.
 
@@ -1465,7 +1465,7 @@ class LineBotApi(object):
 
         return InsightFollowersResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.insight import Insight' and 'Insight(...).get_friends_demographics(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_friends_demographics(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_insight_demographic(self, timeout=None):
         """Retrieve the demographic attributes for a bot's friends.
 
@@ -1485,7 +1485,7 @@ class LineBotApi(object):
 
         return InsightDemographicResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.insight import Insight' and 'Insight(...).get_message_event(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_message_event(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_insight_message_event(self, request_id, timeout=None):
         """Return statistics about how users interact with broadcast messages.
 
@@ -1506,7 +1506,7 @@ class LineBotApi(object):
 
         return InsightMessageEventResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_bot_info(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_bot_info(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_bot_info(self, timeout=None):
         """Get a bot's basic information.
 
@@ -1526,7 +1526,7 @@ class LineBotApi(object):
 
         return BotInfo.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).create_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).create_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def create_audience_group(self, audience_group_name, audiences=None,
                               is_ifa=False, timeout=None):
         """Create an audience group.
@@ -1555,7 +1555,7 @@ class LineBotApi(object):
 
         return CreateAudienceGroup.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).get_audience_data(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_audience_data(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_audience_group(self, audience_group_id, timeout=None):
         """Get the object of audience group.
 
@@ -1577,7 +1577,7 @@ class LineBotApi(object):
 
         return AudienceGroup.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).get_audience_groups(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_audience_groups(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_audience_group_list(self, page=1, description=None, status=None, size=20,
                                 include_external_public_group=None, create_route=None,
                                 timeout=None):
@@ -1621,7 +1621,7 @@ class LineBotApi(object):
                                                    create_route, timeout)
         return result
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).delete_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).delete_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def delete_audience_group(self, audience_group_id, timeout=None):
         """Delete an existing audience.
 
@@ -1639,7 +1639,7 @@ class LineBotApi(object):
             timeout=timeout
         )
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).update_audience_group_description(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).update_audience_group_description(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def rename_audience_group(self, audience_group_id, description, timeout=None):
         """Modify the name of an existing audience.
 
@@ -1664,7 +1664,7 @@ class LineBotApi(object):
 
         return ''
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).add_audience_to_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).add_audience_to_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def add_audiences_to_audience_group(self, audience_group_id, audiences,
                                         upload_description=None, timeout=None):
         """Add new user IDs or IFAs to an audience for uploading user IDs.
@@ -1696,7 +1696,7 @@ class LineBotApi(object):
 
         return response.json
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).get_audience_group_authority_level(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_audience_group_authority_level(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_audience_group_authority_level(self, timeout=None):
         """Get the authority level of the audience.
 
@@ -1716,7 +1716,7 @@ class LineBotApi(object):
 
         return GetAuthorityLevel.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).update_audience_group_authority_level(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).update_audience_group_authority_level(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def change_audience_group_authority_level(self, authority_level='PUBLIC', timeout=None):
         """Change the authority level of all audiences created in the same channel.
 
@@ -1734,7 +1734,7 @@ class LineBotApi(object):
 
         return ''
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).create_click_based_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).create_click_based_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def create_click_audience_group(self, description, request_id,
                                     click_url=None, timeout=None):
         """Create an audience for click-based retargeting.
@@ -1764,7 +1764,7 @@ class LineBotApi(object):
 
         return ClickAudienceGroup.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.audience import ManageAudience' and 'ManageAudience(...).create_imp_based_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).create_imp_based_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def create_imp_audience_group(self, description, request_id,
                                   timeout=None):
         """Create an audience for impression-based retargeting.
@@ -1791,7 +1791,7 @@ class LineBotApi(object):
 
         return ImpAudienceGroup.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).set_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).set_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def set_webhook_endpoint(self, webhook_endpoint, timeout=None):
         """Set the webhook endpoint URL.
 
@@ -1818,7 +1818,7 @@ class LineBotApi(object):
 
         return response.json
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_webhook_endpoint(self, timeout=None):
         """Get information on a webhook endpoint.
 
@@ -1835,7 +1835,7 @@ class LineBotApi(object):
 
         return GetWebhookResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).test_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).test_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def test_webhook_endpoint(self, webhook_endpoint=None, timeout=None):
         """Checks if the configured webhook endpoint can receive a test webhook event.
 
@@ -1864,7 +1864,7 @@ class LineBotApi(object):
 
         return TestWebhookResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_followers(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_followers(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_followers_ids(self, limit=300, start=None, timeout=None):
         """Get a list of users who added your LINE Official Account as a friend.
 
@@ -2016,7 +2016,7 @@ class LineBotApi(object):
                              timeout=timeout)
         return ValidAccessTokenKeyIDsResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.insight import Insight' and 'Insight(...).get_statistics_per_unit(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_statistics_per_unit(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_statistics_per_unit(self, custom_aggregation_unit, from_date, to_date, timeout=None):
         """Return statistics about how users interact with push and multicast messages.
 
@@ -2047,7 +2047,7 @@ class LineBotApi(object):
 
         return InsightMessageEventOfCustomAggregationUnitResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_aggregation_unit_usage(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_aggregation_unit_usage(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_number_of_units_used_this_month(self, timeout=None):
         """Return the number of aggregation units used this month.
 
@@ -2063,7 +2063,7 @@ class LineBotApi(object):
         response = self._get('/v2/bot/message/aggregation/info', timeout=timeout)
         return AggregationInfoResponse.new_from_json_dict(response.json)
 
-    @deprecated(reason="Use 'from linebot.v3.messaging import MessagingApi' and 'MessagingApi(...).get_aggregation_unit_name_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
+    @deprecated(reason="Use 'from linebot.v3 import LineBotClient' and 'LineBotClient(...).get_aggregation_unit_name_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
     def get_name_list_of_units_used_this_month(self, limit=100, start=None, timeout=None):
         """Return the name list of units used this month for statistics aggregation.
 

--- a/linebot/async_api.py
+++ b/linebot/async_api.py
@@ -83,7 +83,7 @@ from deprecated import deprecated
 
 
 @deprecated(
-    reason="Use v3 class; linebot.v3.<feature>. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+    reason="Use 'from linebot.v3 import AsyncLineBotClient'. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
     version="3.0.0",
     category=LineBotSdkDeprecatedIn30,
 )  # noqa: E501
@@ -105,6 +105,7 @@ class AsyncLineBotApi(object):
         :param str channel_access_token: Your channel access token
         :param str endpoint: (optional) Default is https://api.line.me
         :param str data_endpoint: (optional) Default is https://api-data.line.me
+
         """
         self.data_endpoint = data_endpoint
         self.endpoint = endpoint
@@ -116,7 +117,7 @@ class AsyncLineBotApi(object):
         self.async_http_client = async_http_client
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).reply_message(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).reply_message(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -164,7 +165,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).push_message(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).push_message(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -222,7 +223,7 @@ class AsyncLineBotApi(object):
         await self._post("/v2/bot/message/push", data=json.dumps(data), timeout=timeout)
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).multicast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).multicast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -285,7 +286,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).broadcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).broadcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -330,7 +331,7 @@ class AsyncLineBotApi(object):
         return BroadcastResponse(request_id=response.headers.get("X-Line-Request-Id"))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).narrowcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).narrowcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -392,7 +393,7 @@ class AsyncLineBotApi(object):
         return NarrowcastResponse(request_id=response.headers.get("X-Line-Request-Id"))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_narrowcast_progress(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_narrowcast_progress(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -423,7 +424,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).validate_reply(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).validate_reply(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -462,7 +463,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).validate_push(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).validate_push(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -501,7 +502,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).validate_multicast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).validate_multicast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -540,7 +541,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).validate_broadcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).validate_broadcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -579,7 +580,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).validate_narrowcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).validate_narrowcast(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -620,7 +621,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_number_of_sent_broadcast_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_number_of_sent_broadcast_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -649,7 +650,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_number_of_sent_reply_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_number_of_sent_reply_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -676,7 +677,7 @@ class AsyncLineBotApi(object):
         return MessageDeliveryReplyResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_number_of_sent_push_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_number_of_sent_push_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -703,7 +704,7 @@ class AsyncLineBotApi(object):
         return MessageDeliveryPushResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_number_of_sent_multicast_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_number_of_sent_multicast_messages(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -732,7 +733,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -759,7 +760,7 @@ class AsyncLineBotApi(object):
         return Profile.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_group_summary(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_group_summary(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -788,7 +789,7 @@ class AsyncLineBotApi(object):
         return Group.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_group_member_count(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_group_member_count(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -816,7 +817,7 @@ class AsyncLineBotApi(object):
         return (await response.json).get("count")
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_room_member_count(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_room_member_count(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -844,7 +845,7 @@ class AsyncLineBotApi(object):
         return (await response.json).get("count")
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_group_member_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_group_member_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -877,7 +878,7 @@ class AsyncLineBotApi(object):
         return Profile.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_room_member_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_room_member_profile(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -910,7 +911,7 @@ class AsyncLineBotApi(object):
         return Profile.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_group_members_ids(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_group_members_ids(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -944,7 +945,7 @@ class AsyncLineBotApi(object):
         return MemberIds.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_room_members_ids(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_room_members_ids(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -978,7 +979,7 @@ class AsyncLineBotApi(object):
         return MemberIds.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApiBlob' and 'AsyncMessagingApiBlob(...).get_message_content(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_message_content(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1007,7 +1008,7 @@ class AsyncLineBotApi(object):
         return Content(response)
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).leave_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).leave_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1030,7 +1031,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).leave_room(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).leave_room(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1053,7 +1054,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1079,7 +1080,7 @@ class AsyncLineBotApi(object):
         return RichMenuResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1106,7 +1107,7 @@ class AsyncLineBotApi(object):
         return RichMenuAliasResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_rich_menu_alias_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_rich_menu_alias_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1127,7 +1128,7 @@ class AsyncLineBotApi(object):
         return RichMenuAliasListResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).validate_rich_menu_object(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).validate_rich_menu_object(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1151,7 +1152,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).create_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).create_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1177,7 +1178,7 @@ class AsyncLineBotApi(object):
         return (await response.json).get("richMenuId")
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).create_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).create_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1203,7 +1204,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).update_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).update_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1234,7 +1235,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).delete_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).delete_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1256,7 +1257,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).delete_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).delete_rich_menu_alias(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1280,7 +1281,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_rich_menu_id_of_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_rich_menu_id_of_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1305,7 +1306,7 @@ class AsyncLineBotApi(object):
         return (await response.json).get("richMenuId")
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).link_rich_menu_id_to_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).link_rich_menu_id_to_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1330,7 +1331,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).link_rich_menu_id_to_users(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).link_rich_menu_id_to_users(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1361,7 +1362,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).unlink_rich_menu_id_from_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).unlink_rich_menu_id_from_user(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1382,7 +1383,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).unlink_rich_menu_id_from_users(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).unlink_rich_menu_id_from_users(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1411,7 +1412,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApiBlob' and 'MessagingApiBlob.get_rich_menu_image(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_rich_menu_image(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1438,7 +1439,7 @@ class AsyncLineBotApi(object):
         return Content(response)
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApiBlob' and 'MessagingApiBlob.set_rich_menu_image(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).set_rich_menu_image(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1469,7 +1470,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_rich_menu_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_rich_menu_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1495,7 +1496,7 @@ class AsyncLineBotApi(object):
         return result
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).set_default_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).set_default_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1519,7 +1520,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_default_rich_menu_id(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_default_rich_menu_id(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1539,7 +1540,7 @@ class AsyncLineBotApi(object):
         return (await response.json).get("richMenuId")
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).cancel_default_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).cancel_default_rich_menu(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1557,7 +1558,7 @@ class AsyncLineBotApi(object):
         await self._delete("/v2/bot/user/all/richmenu", timeout=timeout)
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_message_quota(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_message_quota(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1579,7 +1580,7 @@ class AsyncLineBotApi(object):
         return MessageQuotaResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_message_quota_consumption(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_message_quota_consumption(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1601,7 +1602,7 @@ class AsyncLineBotApi(object):
         return MessageQuotaConsumptionResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).issue_link_token(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).issue_link_token(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1686,7 +1687,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.insight import AsyncInsight' and 'AsyncInsight(...).get_number_of_message_deliveries(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_number_of_message_deliveries(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1711,7 +1712,7 @@ class AsyncLineBotApi(object):
         return InsightMessageDeliveryResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.insight import AsyncInsight' and 'AsyncInsight(...).get_insight_followers(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_insight_followers(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1735,7 +1736,7 @@ class AsyncLineBotApi(object):
         return InsightFollowersResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.insight import AsyncInsight' and 'AsyncInsight(...).get_friends_demographics(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_friends_demographics(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1756,7 +1757,7 @@ class AsyncLineBotApi(object):
         return InsightDemographicResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.insight import AsyncInsight' and 'AsyncInsight(...).get_message_event(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_message_event(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1783,7 +1784,7 @@ class AsyncLineBotApi(object):
         return InsightMessageEventResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_bot_info(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_bot_info(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1804,7 +1805,7 @@ class AsyncLineBotApi(object):
         return BotInfo.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).create_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).create_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1842,7 +1843,7 @@ class AsyncLineBotApi(object):
         return CreateAudienceGroup.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).get_audience_data(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_audience_data(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1869,7 +1870,7 @@ class AsyncLineBotApi(object):
         return AudienceGroup.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).get_audience_groups(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_audience_groups(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1928,7 +1929,7 @@ class AsyncLineBotApi(object):
         return result
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).delete_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).delete_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1949,7 +1950,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).update_audience_group_description(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).update_audience_group_description(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -1981,7 +1982,7 @@ class AsyncLineBotApi(object):
         return ""
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).add_audience_to_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).add_audience_to_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2022,7 +2023,7 @@ class AsyncLineBotApi(object):
         return await response.json
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).get_audience_group_authority_level(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_audience_group_authority_level(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2045,7 +2046,7 @@ class AsyncLineBotApi(object):
         return GetAuthorityLevel.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).update_audience_group_authority_level(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).update_audience_group_authority_level(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2071,7 +2072,7 @@ class AsyncLineBotApi(object):
         return ""
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).create_click_based_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).create_click_based_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2108,7 +2109,7 @@ class AsyncLineBotApi(object):
         return ClickAudienceGroup.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.audience import AsyncManageAudience' and 'AsyncManageAudience(...).create_imp_based_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).create_imp_based_audience_group(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2140,7 +2141,7 @@ class AsyncLineBotApi(object):
         return ImpAudienceGroup.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).set_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).set_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2169,7 +2170,7 @@ class AsyncLineBotApi(object):
         return await response.json
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2190,7 +2191,7 @@ class AsyncLineBotApi(object):
         return GetWebhookResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).test_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).test_webhook_endpoint(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2223,7 +2224,7 @@ class AsyncLineBotApi(object):
         return TestWebhookResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_followers(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_followers(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2409,7 +2410,7 @@ class AsyncLineBotApi(object):
         return ValidAccessTokenKeyIDsResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.insight import AsyncInsight' and 'AsyncInsight(...).get_statistics_per_unit(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_statistics_per_unit(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2450,7 +2451,7 @@ class AsyncLineBotApi(object):
         )
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_aggregation_unit_usage(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_aggregation_unit_usage(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501
@@ -2470,7 +2471,7 @@ class AsyncLineBotApi(object):
         return AggregationInfoResponse.new_from_json_dict((await response.json))
 
     @deprecated(
-        reason="Use 'from linebot.v3.messaging import AsyncMessagingApi' and 'AsyncMessagingApi(...).get_aggregation_unit_name_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
+        reason="Use 'from linebot.v3 import AsyncLineBotClient' and 'AsyncLineBotClient(...).get_aggregation_unit_name_list(...)' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.",
         version="3.0.0",
         category=LineBotSdkDeprecatedIn30,
     )  # noqa: E501

--- a/linebot/async_http_client.py
+++ b/linebot/async_http_client.py
@@ -20,7 +20,11 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 
 from future.utils import with_metaclass
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AsyncHttpClient(with_metaclass(ABCMeta)):
     """Abstract Base Classes of HttpClient."""
 
@@ -108,6 +112,7 @@ class AsyncHttpClient(with_metaclass(ABCMeta)):
         raise NotImplementedError
 
 
+@deprecated(reason="Use 'linebot.v3' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AsyncHttpResponse(with_metaclass(ABCMeta)):
     """HttpResponse."""
 

--- a/linebot/constants/postback_input_option.py
+++ b/linebot/constants/postback_input_option.py
@@ -12,7 +12,11 @@
 
 """linebot.constants.postback_input_option module."""
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'from linebot.v3.messaging import PostbackAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class PostbackInputOption:
     """Constant class for Postback input option."""
 

--- a/linebot/exceptions.py
+++ b/linebot/exceptions.py
@@ -25,6 +25,7 @@ from .deprecations import (
 )
 
 
+@deprecated(reason="Use 'linebot.v3' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class BaseError(with_metaclass(ABCMeta, Exception)):
     """Base Exception class."""
 
@@ -60,6 +61,7 @@ class InvalidSignatureError(BaseError):
         super(InvalidSignatureError, self).__init__(message)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging.exceptions import ApiException' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class LineBotApiError(BaseError):
     """When LINE Messaging API response error, this error will be raised."""
 

--- a/linebot/http_client.py
+++ b/linebot/http_client.py
@@ -20,7 +20,11 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 import requests
 from future.utils import with_metaclass
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class HttpClient(with_metaclass(ABCMeta)):
     """Abstract Base Classes of HttpClient."""
 
@@ -109,6 +113,7 @@ class HttpClient(with_metaclass(ABCMeta)):
         raise NotImplementedError
 
 
+@deprecated(reason="Use 'linebot.v3' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RequestsHttpClient(HttpClient):
     """HttpClient implemented by requests."""
 
@@ -217,6 +222,7 @@ class RequestsHttpClient(HttpClient):
         return RequestsHttpResponse(response)
 
 
+@deprecated(reason="Use 'linebot.v3' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class HttpResponse(with_metaclass(ABCMeta)):
     """HttpResponse."""
 
@@ -255,6 +261,7 @@ class HttpResponse(with_metaclass(ABCMeta)):
         raise NotImplementedError
 
 
+@deprecated(reason="Use 'linebot.v3' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RequestsHttpResponse(HttpResponse):
     """HttpResponse implemented by requests lib's response."""
 

--- a/linebot/models/actions.py
+++ b/linebot/models/actions.py
@@ -21,6 +21,9 @@ from future.utils import with_metaclass
 
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
+
 
 def get_action(action):
     """Get action."""
@@ -51,6 +54,7 @@ def get_actions(actions):
     return new_actions
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Action(with_metaclass(ABCMeta, Base)):
     """Abstract base class of Action."""
 
@@ -64,6 +68,7 @@ class Action(with_metaclass(ABCMeta, Base)):
         self.type = None
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import PostbackAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class PostbackAction(Action):
     """PostbackAction.
 
@@ -105,6 +110,7 @@ class PostbackAction(Action):
         self.fill_in_text = fill_in_text
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import MessageAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageAction(Action):
     """MessageAction.
 
@@ -128,6 +134,7 @@ class MessageAction(Action):
         self.text = text
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import URIAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class URIAction(Action):
     """URIAction.
 
@@ -155,6 +162,7 @@ class URIAction(Action):
         self.alt_uri = self.get_or_new_from_json_dict(alt_uri, AltUri)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import AltUri' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AltUri(with_metaclass(ABCMeta, Base)):
     """AltUri.
 
@@ -177,6 +185,7 @@ class AltUri(with_metaclass(ABCMeta, Base)):
         self.desktop = desktop
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import DatetimePickerAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class DatetimePickerAction(Action):
     """DatetimePickerAction.
 
@@ -217,6 +226,7 @@ class DatetimePickerAction(Action):
         self.min = min
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import CameraAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class CameraAction(Action):
     """CameraAction.
 
@@ -239,6 +249,7 @@ class CameraAction(Action):
         self.label = label
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import CameraRollAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class CameraRollAction(Action):
     """CameraRollAction.
 
@@ -261,6 +272,7 @@ class CameraRollAction(Action):
         self.label = label
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import LocationAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class LocationAction(Action):
     """LocationRollAction.
 
@@ -283,6 +295,7 @@ class LocationAction(Action):
         self.label = label
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import RichMenuSwitchAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RichMenuSwitchAction(Action):
     """RichMenuSwitchAction.
 

--- a/linebot/models/background.py
+++ b/linebot/models/background.py
@@ -21,7 +21,11 @@ from future.utils import with_metaclass
 
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Background(with_metaclass(ABCMeta, Base)):
     """Background."""
 
@@ -35,6 +39,7 @@ class Background(with_metaclass(ABCMeta, Base)):
         self.type = None
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexBoxLinearGradient' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class LinearGradientBackground(Background):
     """LinearGradientBackground."""
 

--- a/linebot/models/emojis.py
+++ b/linebot/models/emojis.py
@@ -21,7 +21,11 @@ from future.utils import with_metaclass
 
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'from linebot.v3.messaging import Emoji' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Emojis(with_metaclass(ABCMeta, Base)):
     """Emojis.
 

--- a/linebot/models/error.py
+++ b/linebot/models/error.py
@@ -17,7 +17,11 @@
 
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'from linebot.v3.messaging import ErrorResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Error(Base):
     """Error response of LINE messaging API.
 
@@ -45,6 +49,7 @@ class Error(Base):
         self.details = new_details
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ErrorDetail' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ErrorDetail(Base):
     """ErrorDetail response of LINE messaging API."""
 

--- a/linebot/models/filter.py
+++ b/linebot/models/filter.py
@@ -21,7 +21,11 @@ from future.utils import with_metaclass
 
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Filter(with_metaclass(ABCMeta, Base)):
     """Filter.
 
@@ -44,6 +48,7 @@ class Filter(with_metaclass(ABCMeta, Base)):
         self.demographic = demographic
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class DemographicFilter(Filter):
     """DemographicFilter.
 
@@ -65,6 +70,7 @@ class DemographicFilter(Filter):
         self.type = None
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import GenderDemographicFilter' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class GenderFilter(DemographicFilter):
     """GenderFilter."""
 
@@ -85,6 +91,7 @@ class GenderFilter(DemographicFilter):
         self.one_of = one_of
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import AppTypeDemographicFilter' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AppTypeFilter(DemographicFilter):
     """AppTypeFilter."""
 
@@ -105,6 +112,7 @@ class AppTypeFilter(DemographicFilter):
         self.one_of = one_of
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import AreaDemographicFilter' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AreaFilter(DemographicFilter):
     """AreaFilter."""
 
@@ -123,6 +131,7 @@ class AreaFilter(DemographicFilter):
         self.one_of = one_of
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import AgeDemographicFilter' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AgeFilter(DemographicFilter):
     """AgeFilter.
 
@@ -147,6 +156,7 @@ class AgeFilter(DemographicFilter):
         self.lt = lt
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import SubscriptionPeriodDemographicFilter' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class SubscriptionPeriodFilter(DemographicFilter):
     """SubscriptionPeriodFilter.
 

--- a/linebot/models/flex_message.py
+++ b/linebot/models/flex_message.py
@@ -24,7 +24,11 @@ from .actions import get_action
 from .base import Base
 from .send_messages import SendMessage
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexMessage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class FlexSendMessage(SendMessage):
     """FlexSendMessage.
 
@@ -54,6 +58,7 @@ class FlexSendMessage(SendMessage):
         )
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class FlexContainer(with_metaclass(ABCMeta, Base)):
     """FlexContainer.
 
@@ -72,6 +77,7 @@ class FlexContainer(with_metaclass(ABCMeta, Base)):
         self.type = None
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexBubble' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class BubbleContainer(FlexContainer):
     """BubbleContainer.
 
@@ -123,6 +129,7 @@ class BubbleContainer(FlexContainer):
         self.action = get_action(action)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexBubbleStyles' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class BubbleStyle(with_metaclass(ABCMeta, Base)):
     """BubbleStyle.
 
@@ -150,6 +157,7 @@ class BubbleStyle(with_metaclass(ABCMeta, Base)):
         self.footer = self.get_or_new_from_json_dict(footer, BlockStyle)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexBlockStyle' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class BlockStyle(with_metaclass(ABCMeta, Base)):
     """BlockStyle.
 
@@ -173,6 +181,7 @@ class BlockStyle(with_metaclass(ABCMeta, Base)):
         self.separator_color = separator_color
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexCarousel' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class CarouselContainer(FlexContainer):
     """CarouselContainer.
 
@@ -202,6 +211,7 @@ class CarouselContainer(FlexContainer):
         self.contents = new_contents
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class FlexComponent(with_metaclass(ABCMeta, Base)):
     """FlexComponent.
 
@@ -220,6 +230,7 @@ class FlexComponent(with_metaclass(ABCMeta, Base)):
         self.type = None
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexBox' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class BoxComponent(FlexComponent):
     """BoxComponent.
 
@@ -349,6 +360,7 @@ class BoxComponent(FlexComponent):
         self.contents = new_contents
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexButton' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ButtonComponent(FlexComponent):
     """ButtonComponent.
 
@@ -411,6 +423,7 @@ class ButtonComponent(FlexComponent):
         self.adjust_mode = adjust_mode
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexFiller' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class FillerComponent(FlexComponent):
     """FillerComponent.
 
@@ -429,6 +442,7 @@ class FillerComponent(FlexComponent):
         self.flex = flex
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexIcon' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class IconComponent(FlexComponent):
     """IconComponent.
 
@@ -477,6 +491,7 @@ class IconComponent(FlexComponent):
         self.aspect_ratio = aspect_ratio
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexImage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ImageComponent(FlexComponent):
     """ImageComponent.
 
@@ -547,6 +562,7 @@ class ImageComponent(FlexComponent):
         self.animated = animated
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexSeparator' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class SeparatorComponent(FlexComponent):
     """SeparatorComponent.
 
@@ -569,6 +585,7 @@ class SeparatorComponent(FlexComponent):
         self.color = color
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexSpan' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class SpanComponent(FlexComponent):
     """SpanComponent.
 
@@ -605,6 +622,7 @@ class SpanComponent(FlexComponent):
         self.decoration = decoration
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexText' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class TextComponent(FlexComponent):
     """TextComponent.
 
@@ -691,6 +709,7 @@ class TextComponent(FlexComponent):
             self.contents = None
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import FlexVideo' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class VideoComponent(FlexComponent):
     """VideoComponent.
 

--- a/linebot/models/imagemap.py
+++ b/linebot/models/imagemap.py
@@ -22,7 +22,11 @@ from future.utils import with_metaclass
 from .base import Base
 from .send_messages import SendMessage
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'from linebot.v3.messaging import ImagemapMessage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ImagemapSendMessage(SendMessage):
     """ImagemapSendMessage.
 
@@ -73,6 +77,7 @@ class ImagemapSendMessage(SendMessage):
         self.actions = new_actions
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ImagemapBaseSize' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class BaseSize(Base):
     """BaseSize.
 
@@ -93,6 +98,7 @@ class BaseSize(Base):
         self.height = height
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ImagemapAction(with_metaclass(ABCMeta, Base)):
     """ImagemapAction.
 
@@ -109,6 +115,7 @@ class ImagemapAction(with_metaclass(ABCMeta, Base)):
         self.type = None
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import URIImagemapAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class URIImagemapAction(ImagemapAction):
     """URIImagemapAction.
 
@@ -130,6 +137,7 @@ class URIImagemapAction(ImagemapAction):
         self.area = self.get_or_new_from_json_dict(area, ImagemapArea)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import MessageImagemapAction' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageImagemapAction(ImagemapAction):
     """MessageImagemapAction.
 
@@ -151,6 +159,7 @@ class MessageImagemapAction(ImagemapAction):
         self.area = self.get_or_new_from_json_dict(area, ImagemapArea)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ImagemapArea' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ImagemapArea(Base):
     """ImagemapArea.
 
@@ -177,6 +186,7 @@ class ImagemapArea(Base):
         self.height = height
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ImagemapVideo' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Video(Base):
     """Video.
 
@@ -205,6 +215,7 @@ class Video(Base):
         self.external_link = self.get_or_new_from_json_dict(external_link, ExternalLink)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ImagemapExternalLink' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ExternalLink(Base):
     """ExternalLink.
 

--- a/linebot/models/insight.py
+++ b/linebot/models/insight.py
@@ -21,7 +21,11 @@ from future.utils import with_metaclass
 
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class DemographicInsight(with_metaclass(ABCMeta, Base)):
     """Abstract Base Class of DemographicInsight."""
 
@@ -35,6 +39,7 @@ class DemographicInsight(with_metaclass(ABCMeta, Base)):
         self.percentage = percentage
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class GenderInsight(DemographicInsight):
     """GenderInsight."""
 
@@ -50,6 +55,7 @@ class GenderInsight(DemographicInsight):
         self.gender = gender
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AgeInsight(DemographicInsight):
     """AgeInsight."""
 
@@ -65,6 +71,7 @@ class AgeInsight(DemographicInsight):
         self.age = age
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AreaInsight(DemographicInsight):
     """AreaInsight."""
 
@@ -80,6 +87,7 @@ class AreaInsight(DemographicInsight):
         self.area = area
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AppTypeInsight(DemographicInsight):
     """AppTypeInsight."""
 
@@ -95,6 +103,7 @@ class AppTypeInsight(DemographicInsight):
         self.app_type = app_type
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class SubscriptionPeriodInsight(DemographicInsight):
     """SubscriptionPeriodInsight."""
 
@@ -110,6 +119,7 @@ class SubscriptionPeriodInsight(DemographicInsight):
         self.subscription_period = subscription_period
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageStatistics(Base):
     """MessageStatistics."""
 
@@ -141,6 +151,7 @@ class MessageStatistics(Base):
         self.unique_media_played_100_percent = unique_media_played_100_percent
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageStatisticsOfCustomAggregationUnit(Base):
     """MessageStatisticsOfCustomAggregationUnit."""
 
@@ -164,6 +175,7 @@ class MessageStatisticsOfCustomAggregationUnit(Base):
         self.unique_media_played_100_percent = unique_media_played_100_percent
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageInsight(Base):
     """MessageInsight."""
 
@@ -213,6 +225,7 @@ class MessageInsight(Base):
         self.unique_media_played_100_percent = unique_media_played_100_percent
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ClickInsight(Base):
     """ClickInsight."""
 
@@ -236,6 +249,7 @@ class ClickInsight(Base):
         self.unique_click_of_request = unique_click_of_request
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class JobInsight(Base):
     """ClickInsight."""
 

--- a/linebot/models/limit.py
+++ b/linebot/models/limit.py
@@ -21,7 +21,11 @@ from future.utils import with_metaclass
 
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Limit(with_metaclass(ABCMeta, Base)):
     """Limit.
 

--- a/linebot/models/operator.py
+++ b/linebot/models/operator.py
@@ -21,7 +21,11 @@ from future.utils import with_metaclass
 
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Operator(with_metaclass(ABCMeta, Base)):
     """Operator.
 
@@ -42,6 +46,7 @@ class Operator(with_metaclass(ABCMeta, Base)):
         self.type = "operator"
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class And(Operator):
     """And.
 
@@ -60,6 +65,7 @@ class And(Operator):
         setattr(self, 'and', args)
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Or(Operator):
     """Or.
 
@@ -78,6 +84,7 @@ class Or(Operator):
         setattr(self, 'or', args)
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Not(Operator):
     """Not.
 

--- a/linebot/models/recipient.py
+++ b/linebot/models/recipient.py
@@ -21,7 +21,11 @@ from future.utils import with_metaclass
 
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Recipient(with_metaclass(ABCMeta, Base)):
     """Recipient.
 
@@ -41,6 +45,7 @@ class Recipient(with_metaclass(ABCMeta, Base)):
         self.type = None
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import AudienceRecipient' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AudienceRecipient(Recipient):
     """AudienceRecipient."""
 
@@ -57,6 +62,7 @@ class AudienceRecipient(Recipient):
         self.audience_group_id = group_id
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import RedeliveryRecipient' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RedeliveryRecipient(Recipient):
     """RedeliveryRecipient."""
 

--- a/linebot/models/responses.py
+++ b/linebot/models/responses.py
@@ -22,7 +22,11 @@ from .insight import (
 )
 from .rich_menu import RichMenuSize, RichMenuArea, RichMenuAlias
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class BroadcastResponse(object):
     """BroadcastResponse.
 
@@ -37,6 +41,7 @@ class BroadcastResponse(object):
         self.request_id = request_id
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ValidateReplyMessageObjectsResponse(object):
     """ValidateReplyMessageObjectsResponse.
 
@@ -51,6 +56,7 @@ class ValidateReplyMessageObjectsResponse(object):
         self.request_id = request_id
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ValidatePushMessageObjectsResponse(object):
     """ValidatePushMessageObjectsResponse.
 
@@ -65,6 +71,7 @@ class ValidatePushMessageObjectsResponse(object):
         self.request_id = request_id
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ValidateMulticastMessageObjectsResponse(object):
     """ValidateMulticastMessageObjectsResponse.
 
@@ -79,6 +86,7 @@ class ValidateMulticastMessageObjectsResponse(object):
         self.request_id = request_id
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ValidateNarrowcastMessageObjectsResponse(object):
     """ValidateNarrowcastMessageObjectsResponse.
 
@@ -93,6 +101,7 @@ class ValidateNarrowcastMessageObjectsResponse(object):
         self.request_id = request_id
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ValidateBroadcastMessageObjectsResponse(object):
     """ValidateBroadcastMessageObjectsResponse.
 
@@ -107,6 +116,7 @@ class ValidateBroadcastMessageObjectsResponse(object):
         self.request_id = request_id
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import UserProfileResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Profile(Base):
     """Profile.
 
@@ -133,6 +143,7 @@ class Profile(Base):
         self.language = language
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import GroupSummaryResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Group(Base):
     """Group.
 
@@ -154,6 +165,7 @@ class Group(Base):
         self.picture_url = picture_url
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import MembersIdsResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MemberIds(Base):
     """MemberIds.
 
@@ -177,6 +189,7 @@ class MemberIds(Base):
         self.next = next
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Content(object):
     """MessageContent.
 
@@ -221,6 +234,7 @@ class Content(object):
         return self.response.iter_content(chunk_size=chunk_size)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import RichMenuResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RichMenuResponse(Base):
     """RichMenuResponse.
 
@@ -262,6 +276,7 @@ class RichMenuResponse(Base):
         self.areas = new_areas
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import RichMenuAliasResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RichMenuAliasResponse(Base):
     """RichMenuAliasResponse.
 
@@ -281,6 +296,7 @@ class RichMenuAliasResponse(Base):
         self.rich_menu_id = rich_menu_id
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RichMenuAliasListResponse(Base):
     """RichMenuAliasListResponse.
 
@@ -304,6 +320,7 @@ class RichMenuAliasListResponse(Base):
         self.aliases = new_aliases
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import MessageQuotaResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageQuotaResponse(Base):
     """MessageQuotaResponse.
 
@@ -324,6 +341,7 @@ class MessageQuotaResponse(Base):
         self.value = value
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import QuotaConsumptionResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageQuotaConsumptionResponse(Base):
     """MessageQuotaConsumptionResponse.
 
@@ -341,6 +359,7 @@ class MessageQuotaConsumptionResponse(Base):
         self.total_usage = total_usage
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import NumberOfMessagesResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageDeliveryBroadcastResponse(Base):
     """MessageDeliveryBroadcastResponse."""
 
@@ -358,6 +377,7 @@ class MessageDeliveryBroadcastResponse(Base):
         self.success = success
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import NumberOfMessagesResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageDeliveryReplyResponse(Base):
     """MessageDeliveryReplyResponse."""
 
@@ -375,6 +395,7 @@ class MessageDeliveryReplyResponse(Base):
         self.success = success
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import NumberOfMessagesResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageDeliveryPushResponse(Base):
     """MessageDeliveryPushResponse."""
 
@@ -392,6 +413,7 @@ class MessageDeliveryPushResponse(Base):
         self.success = success
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import NumberOfMessagesResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageDeliveryMulticastResponse(Base):
     """MessageDeliveryMulticastResponse."""
 
@@ -409,6 +431,7 @@ class MessageDeliveryMulticastResponse(Base):
         self.success = success
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import NarrowcastProgressResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class MessageProgressNarrowcastResponse(Base):
     """MessageProgressNarrowcastResponse."""
 
@@ -443,6 +466,7 @@ class MessageProgressNarrowcastResponse(Base):
         self.completed_time = completed_time
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import IssueLinkTokenResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class IssueLinkTokenResponse(Base):
     """IssueLinkTokenResponse.
 
@@ -460,6 +484,7 @@ class IssueLinkTokenResponse(Base):
         self.link_token = link_token
 
 
+@deprecated(reason="Use 'linebot.v3.oauth' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class IssueChannelTokenResponse(Base):
     """IssueAccessTokenResponse.
 
@@ -482,6 +507,7 @@ class IssueChannelTokenResponse(Base):
         self.token_type = token_type
 
 
+@deprecated(reason="Use 'from linebot.v3.insight import GetNumberOfMessageDeliveriesResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class InsightMessageDeliveryResponse(Base):
     """InsightMessageDeliveryResponse."""
 
@@ -522,6 +548,7 @@ class InsightMessageDeliveryResponse(Base):
         self.api_reply = api_reply
 
 
+@deprecated(reason="Use 'from linebot.v3.insight import GetNumberOfFollowersResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class InsightFollowersResponse(Base):
     """InsightFollowersResponse."""
 
@@ -545,6 +572,7 @@ class InsightFollowersResponse(Base):
         self.blocks = blocks
 
 
+@deprecated(reason="Use 'from linebot.v3.insight import GetFriendsDemographicsResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class InsightDemographicResponse(Base):
     """InsightDemographicResponse."""
 
@@ -576,6 +604,7 @@ class InsightDemographicResponse(Base):
                                      for it in subscription_periods]
 
 
+@deprecated(reason="Use 'from linebot.v3.insight import GetMessageEventResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class InsightMessageEventResponse(Base):
     """InsightMessageEventResponse."""
 
@@ -597,6 +626,7 @@ class InsightMessageEventResponse(Base):
         self.clicks = [self.get_or_new_from_json_dict(it, ClickInsight) for it in clicks]
 
 
+@deprecated(reason="Use 'linebot.v3.insight' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class InsightMessageEventOfCustomAggregationUnitResponse(Base):
     """InsightMessageEventResponse."""
 
@@ -619,6 +649,7 @@ class InsightMessageEventOfCustomAggregationUnitResponse(Base):
         self.clicks = [self.get_or_new_from_json_dict(it, ClickInsight) for it in clicks]
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AggregationInfoResponse(Base):
     """The number of aggregation units used this month.
 
@@ -636,6 +667,7 @@ class AggregationInfoResponse(Base):
         self.num_of_custom_aggregation_units = num_of_custom_aggregation_units
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AggregationNameListResponse(Base):
     """The name list of units used this month for statistics aggregation.
 
@@ -658,6 +690,7 @@ class AggregationNameListResponse(Base):
         self.next = next
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class NarrowcastResponse(Base):
     """NarrowcastResponse.
 
@@ -675,6 +708,7 @@ class NarrowcastResponse(Base):
         self.request_id = request_id
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import BotInfoResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class BotInfo(Base):
     """Response of `linebot.get_bot_info()` .
 
@@ -699,6 +733,7 @@ class BotInfo(Base):
         self.mark_as_read_mode = mark_as_read_mode
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import GetWebhookEndpointResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class GetWebhookResponse(Base):
     """Response of `get_webhook_endpoint()` .
 
@@ -718,6 +753,7 @@ class GetWebhookResponse(Base):
         self.active = active
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import TestWebhookEndpointResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class TestWebhookResponse(Base):
     """Response of `test_webhook_endpoint()` .
 
@@ -745,6 +781,7 @@ class TestWebhookResponse(Base):
         self.detail = detail
 
 
+@deprecated(reason="Use 'linebot.v3.audience' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AudienceGroup(Base):
     """AudienceGroups.
 
@@ -798,6 +835,7 @@ class AudienceGroup(Base):
             self.jobs = [self.get_or_new_from_json_dict(job, JobInsight) for job in jobs]
 
 
+@deprecated(reason="Use 'linebot.v3.audience' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ClickAudienceGroup(Base):
     """ClickAudienceGroup.
 
@@ -841,6 +879,7 @@ class ClickAudienceGroup(Base):
         self.click_url = click_url
 
 
+@deprecated(reason="Use 'linebot.v3.audience' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class CreateAudienceGroup(Base):
     """ClickAudienceGroup.
 
@@ -879,6 +918,7 @@ class CreateAudienceGroup(Base):
         self.is_ifa_audience = is_ifa_audience
 
 
+@deprecated(reason="Use 'linebot.v3.audience' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ImpAudienceGroup(Base):
     """ImpAudienceGroup.
 
@@ -919,6 +959,7 @@ class ImpAudienceGroup(Base):
         self.request_id = request_id
 
 
+@deprecated(reason="Use 'linebot.v3.audience' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class GetAuthorityLevel(Base):
     """GetAuthorityLevel.
 
@@ -936,6 +977,7 @@ class GetAuthorityLevel(Base):
         self.authority_level = authority_level
 
 
+@deprecated(reason="Use 'linebot.v3.audience' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Audience(Base):
     """Audience.
 
@@ -952,6 +994,7 @@ class Audience(Base):
         self.id = id
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class UserIds(Base):
     """UserIds.
 
@@ -975,6 +1018,7 @@ class UserIds(Base):
         self.next = next
 
 
+@deprecated(reason="Use 'linebot.v3.oauth' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class IssueChannelTokenResponseV2(Base):
     """IssueAccessTokenResponseV2.
 
@@ -999,6 +1043,7 @@ class IssueChannelTokenResponseV2(Base):
         self.key_id = key_id
 
 
+@deprecated(reason="Use 'linebot.v3.oauth' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ChannelAccessTokens(Base):
     """ChannelAccessTokens.
 
@@ -1018,6 +1063,7 @@ class ChannelAccessTokens(Base):
         self.access_tokens = access_tokens
 
 
+@deprecated(reason="Use 'linebot.v3.oauth' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class VerifyChannelTokenResponseV2(Base):
     """VerifyChannelTokenResponseV2.
 
@@ -1041,6 +1087,7 @@ class VerifyChannelTokenResponseV2(Base):
         self.scope = scope
 
 
+@deprecated(reason="Use 'linebot.v3.oauth' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ValidAccessTokenKeyIDsResponse(Base):
     """ValidAccessTokenKeyIDsResponse.
 

--- a/linebot/models/rich_menu.py
+++ b/linebot/models/rich_menu.py
@@ -22,7 +22,11 @@ from future.utils import with_metaclass
 from .actions import get_action
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'from linebot.v3.messaging import RichMenuRequest' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RichMenu(with_metaclass(ABCMeta, Base)):
     """RichMenu.
 
@@ -62,6 +66,7 @@ class RichMenu(with_metaclass(ABCMeta, Base)):
         self.areas = new_areas
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import RichMenuSize' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RichMenuSize(with_metaclass(ABCMeta, Base)):
     """RichMenuSize.
 
@@ -81,6 +86,7 @@ class RichMenuSize(with_metaclass(ABCMeta, Base)):
         self.height = height
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import RichMenuArea' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RichMenuArea(with_metaclass(ABCMeta, Base)):
     """RichMenuArea.
 
@@ -102,6 +108,7 @@ class RichMenuArea(with_metaclass(ABCMeta, Base)):
         self.action = get_action(action)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import RichMenuBounds' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RichMenuBounds(with_metaclass(ABCMeta, Base)):
     """RichMenuBounds.
 
@@ -125,6 +132,7 @@ class RichMenuBounds(with_metaclass(ABCMeta, Base)):
         self.height = height
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import RichMenuAliasResponse' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class RichMenuAlias(with_metaclass(ABCMeta, Base)):
     """RichMenuAlias.
 

--- a/linebot/models/send_messages.py
+++ b/linebot/models/send_messages.py
@@ -23,7 +23,11 @@ from .emojis import Emojis
 from .actions import get_action
 from .base import Base
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class SendMessage(with_metaclass(ABCMeta, Base)):
     """Abstract Base Class of SendMessage."""
 
@@ -43,6 +47,7 @@ class SendMessage(with_metaclass(ABCMeta, Base)):
         self.sender = self.get_or_new_from_json_dict(sender, Sender)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import TextMessage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class TextSendMessage(SendMessage):
     """TextSendMessage.
 
@@ -75,6 +80,7 @@ class TextSendMessage(SendMessage):
             self.emojis = emojis
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ImageMessage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ImageSendMessage(SendMessage):
     """ImageSendMessage.
 
@@ -107,6 +113,7 @@ class ImageSendMessage(SendMessage):
         self.preview_image_url = preview_image_url
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import VideoMessage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class VideoSendMessage(SendMessage):
     """VideoSendMessage.
 
@@ -137,6 +144,7 @@ class VideoSendMessage(SendMessage):
         self.tracking_id = tracking_id
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import AudioMessage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class AudioSendMessage(SendMessage):
     """AudioSendMessage.
 
@@ -162,6 +170,7 @@ class AudioSendMessage(SendMessage):
         self.duration = duration
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import LocationMessage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class LocationSendMessage(SendMessage):
     """LocationSendMessage.
 
@@ -190,6 +199,7 @@ class LocationSendMessage(SendMessage):
         self.longitude = longitude
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import StickerMessage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class StickerSendMessage(SendMessage):
     """StickerSendMessage.
 
@@ -213,6 +223,7 @@ class StickerSendMessage(SendMessage):
         self.sticker_id = sticker_id
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import QuickReply' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class QuickReply(with_metaclass(ABCMeta, Base)):
     """QuickReply.
 
@@ -237,6 +248,7 @@ class QuickReply(with_metaclass(ABCMeta, Base)):
         self.items = new_items
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import QuickReplyItem' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class QuickReplyButton(with_metaclass(ABCMeta, Base)):
     """QuickReplyButton.
 
@@ -259,6 +271,7 @@ class QuickReplyButton(with_metaclass(ABCMeta, Base)):
         self.action = get_action(action)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import Sender' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Sender(with_metaclass(ABCMeta, Base)):
     """Sender.
 

--- a/linebot/models/template.py
+++ b/linebot/models/template.py
@@ -23,7 +23,11 @@ from .actions import get_action, get_actions
 from .base import Base
 from .send_messages import SendMessage
 
+from deprecated import deprecated
+from linebot.deprecations import LineBotSdkDeprecatedIn30
 
+
+@deprecated(reason="Use 'from linebot.v3.messaging import TemplateMessage' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class TemplateSendMessage(SendMessage):
     """TemplateSendMessage.
 
@@ -56,6 +60,7 @@ class TemplateSendMessage(SendMessage):
         )
 
 
+@deprecated(reason="Use 'linebot.v3.messaging' module instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class Template(with_metaclass(ABCMeta, Base)):
     """Abstract Base Class of Template."""
 
@@ -69,6 +74,7 @@ class Template(with_metaclass(ABCMeta, Base)):
         self.type = None
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ButtonsTemplate' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ButtonsTemplate(Template):
     """ButtonsTemplate.
 
@@ -122,6 +128,7 @@ class ButtonsTemplate(Template):
         self.default_action = get_action(default_action)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ConfirmTemplate' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ConfirmTemplate(Template):
     """ConfirmTemplate.
 
@@ -147,6 +154,7 @@ class ConfirmTemplate(Template):
         self.actions = get_actions(actions)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import CarouselTemplate' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class CarouselTemplate(Template):
     """CarouselTemplate.
 
@@ -182,6 +190,7 @@ class CarouselTemplate(Template):
         self.image_size = image_size
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ImageCarouselTemplate' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ImageCarouselTemplate(Template):
     """ImageCarouselTemplate.
 
@@ -211,6 +220,7 @@ class ImageCarouselTemplate(Template):
         self.columns = new_columns
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import CarouselColumn' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class CarouselColumn(Base):
     """CarouselColumn.
 
@@ -249,6 +259,7 @@ class CarouselColumn(Base):
         self.default_action = get_action(default_action)
 
 
+@deprecated(reason="Use 'from linebot.v3.messaging import ImageCarouselColumn' instead. See https://github.com/line/line-bot-sdk-python/blob/master/README.rst for more details.", version='3.0.0', category=LineBotSdkDeprecatedIn30)  # noqa: E501
 class ImageCarouselColumn(Base):
     """ImageCarouselColumn.
 


### PR DESCRIPTION
## Motivation

With `LineBotClient` / `AsyncLineBotClient` available as the recommended entry point, the legacy `linebot` (v2) modules should be explicitly marked as deprecated to guide users toward
migration.

## What's changed

### Deprecation annotations

- **`linebot/api.py`**: Updated all `@deprecated` messages on `LineBotApi` class and every method to point to `LineBotClient` instead of individual v3 API classes (e.g., `MessagingApi`)
- **`linebot/async_api.py`**: Same treatment for `AsyncLineBotApi`, pointing to `AsyncLineBotClient`
- **`linebot/models/*.py`** (13 files): Added `@deprecated` decorator to all model classes (`Action`, `PostbackAction`, `FlexMessage`, `RichMenuSize`, etc.) pointing to their
`linebot.v3.messaging` / `linebot.v3.webhooks` equivalents
- **`linebot/http_client.py`**, **`linebot/async_http_client.py`**, **`linebot/aiohttp_async_http_client.py`**: Added `@deprecated` to `HttpClient`, `RequestsHttpClient`,
`AsyncHttpClient`, etc.
- **`linebot/exceptions.py`**: Added `@deprecated` to `BaseError` and `LineBotApiError`
- **`linebot/constants/postback_input_option.py`**: Added `@deprecated`

### MIGRATION.md
Comprehensive migration guide covering:
- Client construction (before/after)
- Import mapping (`linebot.models` → `linebot.v3.messaging` / `linebot.v3.webhooks`)
- Method name mapping with examples
- Error handling changes
- Full before/after echo-bot example

### README.rst

- Added link to `MIGRATION.md` in the Version 3.x section
