### PR TITLE
Remove pytest-pep8 incompatible with pytest 9.1

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest==9.0.3
+pytest==9.1.1
 pytest-pep8==1.0.6
 pytest-cov==7.1.0
 pytest-aiohttp==1.1.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 pytest==9.1.1
-pytest-pep8==1.0.6
 pytest-cov==7.1.0
 pytest-aiohttp==1.1.1
 pytest-asyncio==1.4.0


### PR DESCRIPTION
## Summary

- `pytest-pep8==1.0.6` (last released in 2014) registers a `pytest_collect_file` hook using the `path` argument, which was removed from the hookspec in pytest 9.1.
- This makes test collection fail on #1022, breaking all `build` jobs with `PluginValidationError: Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec`.
- The plugin is unused (no `--pep8` flag or pep8 config anywhere); code style is already enforced by the separate `flake8` tox environments, so the dependency can be removed safely.