### PR TITLE
Fix CI failure with tox 4.56 by setting skip_missing_interpreters = true

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 -r requirements-test.txt
-tox==4.55.1 ; python_version >= "3.10"
-tox==4.55.1 ; python_version < "3.10"
+tox==4.56.1 ; python_version >= "3.10"
+tox==4.56.1 ; python_version < "3.10"
 wheel==0.47.0
 Sphinx==9.0.4 ; python_version >= "3.11"
 Sphinx==7.4.7 ; python_version < "3.11"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 -r requirements-test.txt
-tox==4.56.1 ; python_version >= "3.10"
-tox==4.56.1 ; python_version < "3.10"
+tox==4.56.1
 wheel==0.47.0
 Sphinx==9.0.4 ; python_version >= "3.11"
 Sphinx==7.4.7 ; python_version < "3.11"

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,8 @@
 [tox]
+# tox 4.56.0 changed the default of skip_missing_interpreters back to false
+# (https://github.com/tox-dev/tox/pull/3966). CI runners install only one
+# Python version per job, so missing interpreters must be skipped, not failed.
+skip_missing_interpreters = true
 envlist =
     py3.10,
     py3.11,


### PR DESCRIPTION
## Summary

Supersedes #1026 (Renovate update of tox 4.55.1 -> 4.56.1), whose CI is failing.

tox 4.56.0 changed the default of `skip_missing_interpreters` back to `false` (tox-dev/tox#3966).

The `build` job in `.github/workflows/auto-testing.yml` is a matrix where each runner installs only a single Python version and then runs plain `tox`, so all envs for interpreters not installed on that runner (e.g. `py3.10` on the 3.11 runner) now fail with "could not find python interpreter" instead of being skipped.

This PR adds `skip_missing_interpreters = true` to the `[tox]` section of `tox.ini` to restore the previous behavior.